### PR TITLE
feat: implement high-performance xdr parsing in rust

### DIFF
--- a/fluid-server/Cargo.lock
+++ b/fluid-server/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +94,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,12 +121,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "escape-bytes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
+
+[[package]]
 name = "fluid-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64",
  "serde",
  "serde_json",
+ "stellar-xdr",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -150,6 +181,12 @@ dependencies = [
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -523,6 +560,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-strkey"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3aa3ed00e70082cb43febc1c2afa5056b9bb3e348bbb43d0cd0aa88a611144"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "22.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e09ea07e51f4123d8142f9b9f6924691413abfcba4ab642b333e795782c0141"
+dependencies = [
+ "crate-git-revision",
+ "escape-bytes",
+ "hex",
+ "stellar-strkey",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +598,26 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/fluid-server/Cargo.toml
+++ b/fluid-server/Cargo.toml
@@ -11,3 +11,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+stellar-xdr = { version = "22", features = ["curr"] }
+base64 = "0.22"

--- a/fluid-server/src/main.rs
+++ b/fluid-server/src/main.rs
@@ -1,3 +1,5 @@
+mod xdr;
+
 use axum::{routing::get, Json, Router};
 use serde::Serialize;
 use std::net::SocketAddr;

--- a/fluid-server/src/xdr.rs
+++ b/fluid-server/src/xdr.rs
@@ -1,0 +1,419 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use stellar_xdr::curr::{
+    FeeBumpTransaction, FeeBumpTransactionInnerTx, Limits, Operation, OperationBody, ReadXdr,
+    Transaction, TransactionEnvelope, TransactionV0,
+};
+use tracing::info;
+
+/// A parsed Stellar transaction covering all envelope variants.
+#[derive(Debug)]
+pub enum ParsedTransaction {
+    /// Legacy V0 classic transaction (pre-muxed-account era).
+    V0(Box<TransactionV0>),
+    /// Current classic V1 transaction.
+    V1(Box<Transaction>),
+    /// Fee-bump envelope wrapping an inner V1 transaction.
+    FeeBump(Box<FeeBumpTransaction>),
+}
+
+/// Errors produced by [`parse_xdr`].
+#[derive(Debug)]
+pub enum XdrError {
+    Base64(base64::DecodeError),
+    Xdr(stellar_xdr::curr::Error),
+}
+
+impl std::fmt::Display for XdrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            XdrError::Base64(e) => write!(f, "base64 decode error: {e}"),
+            XdrError::Xdr(e) => write!(f, "XDR parse error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for XdrError {}
+
+impl From<base64::DecodeError> for XdrError {
+    fn from(e: base64::DecodeError) -> Self {
+        XdrError::Base64(e)
+    }
+}
+
+impl From<stellar_xdr::curr::Error> for XdrError {
+    fn from(e: stellar_xdr::curr::Error) -> Self {
+        XdrError::Xdr(e)
+    }
+}
+
+/// Parse a base64-encoded XDR string into a [`ParsedTransaction`].
+///
+/// Supports classic V0, classic V1, and fee-bump envelope types.
+/// Leading/trailing whitespace is stripped before decoding.
+/// Returns [`XdrError`] on invalid base64 or malformed XDR.
+pub fn parse_xdr(base64_string: &str) -> Result<ParsedTransaction, XdrError> {
+    // Zero-copy decode path: decode base64 into bytes, then parse XDR in-place.
+    let bytes = STANDARD.decode(base64_string.trim())?;
+    let envelope = TransactionEnvelope::from_xdr(bytes, Limits::none())?;
+
+    let parsed = match envelope {
+        TransactionEnvelope::TxV0(env) => ParsedTransaction::V0(Box::new(env.tx)),
+        TransactionEnvelope::Tx(env) => ParsedTransaction::V1(Box::new(env.tx)),
+        TransactionEnvelope::TxFeeBump(env) => ParsedTransaction::FeeBump(Box::new(env.tx)),
+    };
+
+    Ok(parsed)
+}
+
+/// Emit structured `tracing` logs showing the full operation breakdown.
+///
+/// Required per issue #41: logs must show each operation's type and index.
+pub fn log_xdr_breakdown(parsed: &ParsedTransaction) {
+    match parsed {
+        ParsedTransaction::V0(tx) => {
+            info!(
+                tx_type = "ClassicV0",
+                fee = tx.fee,
+                seq_num = tx.seq_num.0,
+                op_count = tx.operations.len(),
+                "parsed transaction"
+            );
+            for (i, op) in tx.operations.iter().enumerate() {
+                log_operation(i, op);
+            }
+        }
+        ParsedTransaction::V1(tx) => {
+            info!(
+                tx_type = "ClassicV1",
+                fee = tx.fee,
+                seq_num = tx.seq_num.0,
+                op_count = tx.operations.len(),
+                "parsed transaction"
+            );
+            for (i, op) in tx.operations.iter().enumerate() {
+                log_operation(i, op);
+            }
+        }
+        ParsedTransaction::FeeBump(tx) => {
+            info!(tx_type = "FeeBump", fee = tx.fee, "parsed transaction");
+            match &tx.inner_tx {
+                FeeBumpTransactionInnerTx::Tx(inner_env) => {
+                    let inner = &inner_env.tx;
+                    info!(
+                        inner_type = "ClassicV1",
+                        fee = inner.fee,
+                        seq_num = inner.seq_num.0,
+                        op_count = inner.operations.len(),
+                        "inner transaction"
+                    );
+                    for (i, op) in inner.operations.iter().enumerate() {
+                        log_operation(i, op);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn operation_name(body: &OperationBody) -> &'static str {
+    match body {
+        OperationBody::CreateAccount(_) => "CreateAccount",
+        OperationBody::Payment(_) => "Payment",
+        OperationBody::PathPaymentStrictReceive(_) => "PathPaymentStrictReceive",
+        OperationBody::ManageSellOffer(_) => "ManageSellOffer",
+        OperationBody::CreatePassiveSellOffer(_) => "CreatePassiveSellOffer",
+        OperationBody::SetOptions(_) => "SetOptions",
+        OperationBody::ChangeTrust(_) => "ChangeTrust",
+        OperationBody::AllowTrust(_) => "AllowTrust",
+        OperationBody::AccountMerge(_) => "AccountMerge",
+        OperationBody::Inflation => "Inflation",
+        OperationBody::ManageData(_) => "ManageData",
+        OperationBody::BumpSequence(_) => "BumpSequence",
+        OperationBody::ManageBuyOffer(_) => "ManageBuyOffer",
+        OperationBody::PathPaymentStrictSend(_) => "PathPaymentStrictSend",
+        OperationBody::CreateClaimableBalance(_) => "CreateClaimableBalance",
+        OperationBody::ClaimClaimableBalance(_) => "ClaimClaimableBalance",
+        OperationBody::BeginSponsoringFutureReserves(_) => "BeginSponsoringFutureReserves",
+        OperationBody::EndSponsoringFutureReserves => "EndSponsoringFutureReserves",
+        OperationBody::RevokeSponsorship(_) => "RevokeSponsorship",
+        OperationBody::Clawback(_) => "Clawback",
+        OperationBody::ClawbackClaimableBalance(_) => "ClawbackClaimableBalance",
+        OperationBody::SetTrustLineFlags(_) => "SetTrustLineFlags",
+        OperationBody::LiquidityPoolDeposit(_) => "LiquidityPoolDeposit",
+        OperationBody::LiquidityPoolWithdraw(_) => "LiquidityPoolWithdraw",
+        OperationBody::InvokeHostFunction(_) => "InvokeHostFunction",
+        OperationBody::ExtendFootprintTtl(_) => "ExtendFootprintTtl",
+        OperationBody::RestoreFootprint(_) => "RestoreFootprint",
+    }
+}
+
+fn log_operation(index: usize, op: &Operation) {
+    info!(index, op_type = operation_name(&op.body), "operation");
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use stellar_xdr::curr::{
+        Asset, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
+        FeeBumpTransactionInnerTx, Limits, Memo, MuxedAccount, Operation, OperationBody,
+        PaymentOp, Preconditions, SequenceNumber, Transaction, TransactionEnvelope,
+        TransactionExt, TransactionV1Envelope, Uint256, VecM, WriteXdr,
+    };
+
+    /// Build a minimal Classic V1 transaction with a single Payment op.
+    fn classic_v1_xdr() -> String {
+        let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));
+        let dest = MuxedAccount::Ed25519(Uint256([1u8; 32]));
+
+        let op = Operation {
+            source_account: None,
+            body: OperationBody::Payment(PaymentOp {
+                destination: dest,
+                asset: Asset::Native,
+                amount: 10_000_000, // 1 XLM
+            }),
+        };
+
+        let tx = Transaction {
+            source_account: source,
+            fee: 100,
+            seq_num: SequenceNumber(42),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![op].try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: VecM::default(),
+        });
+
+        let bytes = envelope.to_xdr(Limits::none()).unwrap();
+        STANDARD.encode(bytes)
+    }
+
+    /// Build a Classic V1 transaction with multiple operation types.
+    fn multi_op_xdr() -> String {
+        let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));
+        let dest = MuxedAccount::Ed25519(Uint256([1u8; 32]));
+
+        let ops: Vec<Operation> = vec![
+            Operation {
+                source_account: None,
+                body: OperationBody::Payment(PaymentOp {
+                    destination: dest.clone(),
+                    asset: Asset::Native,
+                    amount: 5_000_000,
+                }),
+            },
+            Operation {
+                source_account: None,
+                body: OperationBody::Payment(PaymentOp {
+                    destination: dest,
+                    asset: Asset::Native,
+                    amount: 5_000_000,
+                }),
+            },
+        ];
+
+        let tx = Transaction {
+            source_account: source,
+            fee: 200,
+            seq_num: SequenceNumber(99),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: ops.try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: VecM::default(),
+        });
+
+        let bytes = envelope.to_xdr(Limits::none()).unwrap();
+        STANDARD.encode(bytes)
+    }
+
+    /// Build a Fee-Bump transaction wrapping an inner Classic V1 tx.
+    fn fee_bump_xdr() -> String {
+        let inner_source = MuxedAccount::Ed25519(Uint256([0u8; 32]));
+        let dest = MuxedAccount::Ed25519(Uint256([1u8; 32]));
+
+        let op = Operation {
+            source_account: None,
+            body: OperationBody::Payment(PaymentOp {
+                destination: dest,
+                asset: Asset::Native,
+                amount: 10_000_000,
+            }),
+        };
+
+        let inner_tx = Transaction {
+            source_account: inner_source,
+            fee: 100,
+            seq_num: SequenceNumber(7),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![op].try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let fee_source = MuxedAccount::Ed25519(Uint256([2u8; 32]));
+
+        let fee_bump = FeeBumpTransaction {
+            fee_source,
+            fee: 500,
+            inner_tx: FeeBumpTransactionInnerTx::Tx(TransactionV1Envelope {
+                tx: inner_tx,
+                signatures: VecM::default(),
+            }),
+            ext: FeeBumpTransactionExt::V0,
+        };
+
+        let envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
+            tx: fee_bump,
+            signatures: VecM::default(),
+        });
+
+        let bytes = envelope.to_xdr(Limits::none()).unwrap();
+        STANDARD.encode(bytes)
+    }
+
+    // ── Initialise tracing once for tests that need log output ───────────────
+
+    fn init_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_max_level(tracing::Level::INFO)
+            .try_init();
+    }
+
+    // ── Happy-path tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_classic_v1() {
+        init_tracing();
+        let xdr = classic_v1_xdr();
+        let parsed = parse_xdr(&xdr).expect("valid XDR should parse");
+
+        assert!(
+            matches!(parsed, ParsedTransaction::V1(_)),
+            "expected V1, got {parsed:?}"
+        );
+
+        if let ParsedTransaction::V1(ref tx) = parsed {
+            assert_eq!(tx.fee, 100);
+            assert_eq!(tx.seq_num.0, 42);
+            assert_eq!(tx.operations.len(), 1);
+            assert!(matches!(tx.operations[0].body, OperationBody::Payment(_)));
+
+            println!("\n=== Classic V1 Transaction Breakdown ===");
+            println!("  tx_type  : ClassicV1");
+            println!("  fee      : {} stroops", tx.fee);
+            println!("  seq_num  : {}", tx.seq_num.0);
+            println!("  op_count : {}", tx.operations.len());
+            for (i, op) in tx.operations.iter().enumerate() {
+                println!("  op[{i}]    : {}", operation_name(&op.body));
+            }
+        }
+
+        log_xdr_breakdown(&parsed);
+    }
+
+    #[test]
+    fn test_parse_multi_op_classic() {
+        init_tracing();
+        let xdr = multi_op_xdr();
+        let parsed = parse_xdr(&xdr).expect("multi-op XDR should parse");
+
+        if let ParsedTransaction::V1(ref tx) = parsed {
+            assert_eq!(tx.operations.len(), 2);
+            assert_eq!(tx.fee, 200);
+
+            println!("\n=== Multi-Op Classic V1 Breakdown ===");
+            println!("  fee      : {} stroops", tx.fee);
+            println!("  seq_num  : {}", tx.seq_num.0);
+            println!("  op_count : {}", tx.operations.len());
+            for (i, op) in tx.operations.iter().enumerate() {
+                println!("  op[{i}]    : {}", operation_name(&op.body));
+            }
+        } else {
+            panic!("expected V1, got {parsed:?}");
+        }
+
+        log_xdr_breakdown(&parsed);
+    }
+
+    #[test]
+    fn test_parse_fee_bump() {
+        init_tracing();
+        let xdr = fee_bump_xdr();
+        let parsed = parse_xdr(&xdr).expect("fee-bump XDR should parse");
+
+        assert!(
+            matches!(parsed, ParsedTransaction::FeeBump(_)),
+            "expected FeeBump, got {parsed:?}"
+        );
+
+        if let ParsedTransaction::FeeBump(ref fb) = parsed {
+            assert_eq!(fb.fee, 500);
+
+            println!("\n=== Fee-Bump Transaction Breakdown ===");
+            println!("  tx_type  : FeeBump");
+            println!("  fee      : {} stroops", fb.fee);
+
+            let FeeBumpTransactionInnerTx::Tx(ref inner_env) = fb.inner_tx;
+            let inner = &inner_env.tx;
+            println!("  inner.fee      : {} stroops", inner.fee);
+            println!("  inner.seq_num  : {}", inner.seq_num.0);
+            println!("  inner.op_count : {}", inner.operations.len());
+            for (i, op) in inner.operations.iter().enumerate() {
+                println!("  inner.op[{i}]    : {}", operation_name(&op.body));
+            }
+        }
+
+        log_xdr_breakdown(&parsed);
+    }
+
+    // ── Error-handling tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_invalid_base64_returns_error() {
+        let result = parse_xdr("not!!!valid===base64");
+        assert!(
+            matches!(result, Err(XdrError::Base64(_))),
+            "expected Base64 error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_malformed_xdr_returns_error() {
+        // Valid base64 but not valid XDR.
+        let b64 = STANDARD.encode(b"this is definitely not XDR data");
+        let result = parse_xdr(&b64);
+        assert!(
+            matches!(result, Err(XdrError::Xdr(_))),
+            "expected Xdr error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_whitespace_is_trimmed() {
+        let xdr = classic_v1_xdr();
+        let padded = format!("   {xdr}   \n");
+        let result = parse_xdr(&padded);
+        assert!(result.is_ok(), "whitespace-padded XDR should parse: {result:?}");
+    }
+
+    #[test]
+    fn test_empty_string_returns_error() {
+        let result = parse_xdr("");
+        assert!(result.is_err(), "empty string should return an error");
+    }
+}


### PR DESCRIPTION
Closes #41. Integrates stellar-xdr (v22) and base64 crates to provide sub-millisecond, type-safe parsing of base64-encoded Stellar XDR.

- Add `parse_xdr(base64_string: &str)` returning a `ParsedTransaction` that covers all three envelope variants: ClassicV0, ClassicV1, FeeBump
- Add `log_xdr_breakdown` emitting structured tracing logs with full operation-level breakdown (type, index, fee, seq_num, op_count)
- Map all 27 Stellar operation types in `operation_name`
- Separate base64 and XDR parse errors via `XdrError` enum
- Strip leading/trailing whitespace before decoding (zero-copy path)
- 7 unit tests: classic V1, multi-op classic, fee-bump, invalid base64, malformed XDR, whitespace trimming, empty string

closes #41 