### PR TITLE
feat(fluid-py): initialize Python SDK for fee-bump sponsorship

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,12 @@ FLUID_GRPC_ENGINE_PINNED_CLIENT_CERT_SHA256=
 # When present, CI machines share build artifacts, dramatically reducing cold
 # build times. Leave blank to fall back to local-only Nx cache.
 NX_CLOUD_AUTH_TOKEN=your_nx_cloud_auth_token_here
+
+# -- fluid-py SDK demo values --------------------------------------------------
+# These values are used by fluid-py/examples/example_fee_bump.py.
+# For issue #113 proof, run with mock server on localhost:3010.
+FLUID_SERVER_URL=http://127.0.0.1:3010
+STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+STELLAR_SOURCE_SECRET=SALKKNYYA3DQHZGGPDJKVSVMMQ6MYEZNGVUUGVNP6RSPYTNFX57EWGAO
+STELLAR_DESTINATION=GDPVBHACK36UGXVKSWIGDNUZD3FQYZE6U63TGVYDMJTGEQYM6TAAKO6O
+HORIZON_URL=https://horizon-testnet.stellar.org

--- a/fluid-py/.gitignore
+++ b/fluid-py/.gitignore
@@ -1,0 +1,40 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Packaging/build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+*.egg
+pip-wheel-metadata/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test and coverage outputs
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.mypy_cache/
+.ruff_cache/
+
+# Tooling and local state
+.tox/
+.nox/
+.ipynb_checkpoints/
+
+# Logs
+*.log
+
+# OS/editor files
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~

--- a/fluid-py/examples/example_fee_bump.py
+++ b/fluid-py/examples/example_fee_bump.py
@@ -1,0 +1,147 @@
+"""Example: request a fee-bump for a Stellar transaction using fluid-py.
+
+This script demonstrates the typical integration with the stellar-sdk Python
+library.  It builds a minimal XDR transaction, hands it to FluidClient, and
+prints the fee-bumped envelope returned by the Fluid server.
+
+Prerequisites
+-------------
+    pip install fluid-py stellar-sdk
+
+Usage
+-----
+    # Against a local or staging Fluid server:
+    FLUID_SERVER_URL=http://localhost:3000 python example_fee_bump.py
+
+    # Or edit the constants below directly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Configuration — edit these or set the corresponding environment variables
+# ---------------------------------------------------------------------------
+FLUID_SERVER_URL: str = os.getenv("FLUID_SERVER_URL", "http://localhost:3000")
+NETWORK_PASSPHRASE: str = os.getenv(
+    "STELLAR_NETWORK_PASSPHRASE", "Test SDF Network ; September 2015"
+)
+SOURCE_SECRET: str = os.getenv(
+    "STELLAR_SOURCE_SECRET",
+    # Generated offline — safe for demo/testnet only, never use on mainnet
+    "SALKKNYYA3DQHZGGPDJKVSVMMQ6MYEZNGVUUGVNP6RSPYTNFX57EWGAO",
+)
+DESTINATION_ACCOUNT: str = os.getenv(
+    "STELLAR_DESTINATION",
+    "GDPVBHACK36UGXVKSWIGDNUZD3FQYZE6U63TGVYDMJTGEQYM6TAAKO6O",
+)
+HORIZON_URL: str = os.getenv(
+    "HORIZON_URL", "https://horizon-testnet.stellar.org"
+)
+
+# ---------------------------------------------------------------------------
+# Build a minimal inner transaction with stellar-sdk
+# ---------------------------------------------------------------------------
+try:
+    from stellar_sdk import (
+        Account,
+        Asset,
+        Keypair,
+        Network,
+        TransactionBuilder,
+    )
+    HAS_STELLAR_SDK = True
+except ImportError:
+    HAS_STELLAR_SDK = False
+
+
+def build_inner_xdr() -> str:
+    """Build a minimal Stellar payment transaction and return its XDR.
+
+    Built entirely offline (no Horizon account load required), so this
+    works with any keypair — funded or not — for demo purposes.
+
+    Returns:
+        Base64-encoded XDR string for the signed inner transaction.
+    """
+    if not HAS_STELLAR_SDK:
+        print(
+            "stellar-sdk is not installed.  Falling back to a hard-coded XDR "
+            "placeholder.\n"
+            "Install it with:  pip install stellar-sdk",
+            file=sys.stderr,
+        )
+        # Minimal XDR placeholder so the example still runs without stellar-sdk
+        return (
+            "AAAAAgAAAABexRErfVD8RgHqf8wZXbJiV1FPpqQdTmNYUA+HFVQ5UwAAAGQA"
+            "AAABAAAAAAAAAAAAAAABAAAAAAAAAA=="
+        )
+
+    keypair = Keypair.from_secret(SOURCE_SECRET)
+    # Build offline: stub Account with sequence 0 — no Horizon needed
+    source_account = Account(keypair.public_key, 0)
+
+    tx = (
+        TransactionBuilder(
+            source_account=source_account,
+            network_passphrase=NETWORK_PASSPHRASE,
+            base_fee=100,
+        )
+        .append_payment_op(
+            destination=DESTINATION_ACCOUNT,
+            asset=Asset.native(),
+            amount="0.0000001",
+        )
+        .set_timeout(30)
+        .build()
+    )
+    tx.sign(keypair)
+    return tx.to_xdr()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> None:
+    """Request a fee-bump and print the result."""
+    from fluid_py import FluidClient, FluidClientConfig
+
+    print(f"Fluid server : {FLUID_SERVER_URL}")
+    print(f"Network      : {NETWORK_PASSPHRASE}\n")
+
+    # 1. Build (or load) the inner transaction XDR
+    print("Building inner transaction …")
+    inner_xdr = build_inner_xdr()
+    print(f"Inner XDR    : {inner_xdr[:60]}…\n")
+
+    # 2. Create the FluidClient
+    config = FluidClientConfig(
+        server_url=FLUID_SERVER_URL,
+        network_passphrase=NETWORK_PASSPHRASE,
+        horizon_url=HORIZON_URL,
+    )
+    client = FluidClient(config)
+    print(f"Client       : {client}\n")
+
+    # 3. Request the fee-bump
+    print("Requesting fee-bump …")
+    response = client.request_fee_bump(inner_xdr, submit=False)
+
+    # 4. Print results
+    print("=== Fee-Bump Response ===")
+    print(f"Status     : {response.status}")
+    print(f"XDR        : {response.xdr[:60]}…")
+    if response.hash:
+        print(f"Hash       : {response.hash}")
+    if response.fee_payer:
+        print(f"Fee payer  : {response.fee_payer}")
+    if response.submitted_via:
+        print(f"Submitted  : {response.submitted_via}")
+
+    print("\nSuccess! fee-bump envelope received from Fluid server.")
+
+
+if __name__ == "__main__":
+    main()

--- a/fluid-py/examples/mock_fluid_server.py
+++ b/fluid-py/examples/mock_fluid_server.py
@@ -1,0 +1,98 @@
+"""Minimal local mock of the Fluid fee-bump server.
+
+Used for local development and demo purposes when the full Rust/Node
+Fluid server is not available.
+
+Usage::
+
+    python examples/mock_fluid_server.py          # listens on :3000
+    python examples/mock_fluid_server.py --port 4000
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(message)s")
+log = logging.getLogger("mock-fluid")
+
+# Simulated fee-payer public key (Stellar testnet well-known key)
+_FEE_PAYER = "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3MKZTJW3GV"
+_MOCK_HASH = "a3f2c1d4e5b6a7890123456789abcdef0123456789abcdef0123456789abcdef01"
+_MOCK_FEE_BUMP_XDR = (
+    "AAAABQAAAABexRErfVD8RgHqf8wZXbJiV1FPpqQdTmNYUA+HFVQ5UwAAAAAAAAGQ"
+    "AAAAAgAAAABexRErfVD8RgHqf8wZXbJiV1FPpqQdTmNYUA+HFVQ5UwAAAGQAAAAB"
+    "AAAAAAAAAAAAAAABAAAAAAAAAAAAAAA="
+)
+
+
+class FluidMockHandler(BaseHTTPRequestHandler):
+    """Handle POST /fee-bump and POST /fee-bump/batch."""
+
+    def log_message(self, fmt: str, *args: object) -> None:  # silence default log
+        log.info(fmt, *args)
+
+    def _read_body(self) -> dict:  # type: ignore[type-arg]
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        return json.loads(raw) if raw else {}
+
+    def _send_json(self, status: int, payload: object) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802
+        body = self._read_body()
+
+        if self.path == "/fee-bump":
+            inner_xdr: str = body.get("xdr", "")
+            submit: bool = bool(body.get("submit", False))
+            log.info("fee-bump  xdr=%s…  submit=%s", inner_xdr[:20], submit)
+            self._send_json(200, {
+                "xdr": _MOCK_FEE_BUMP_XDR,
+                "status": "submitted" if submit else "ready",
+                "hash": _MOCK_HASH,
+                "fee_payer": _FEE_PAYER,
+                "submitted_via": "horizon" if submit else None,
+                "submission_attempts": 1 if submit else None,
+            })
+
+        elif self.path == "/fee-bump/batch":
+            xdrs: list[str] = body.get("xdrs", [])
+            submit = bool(body.get("submit", False))
+            log.info("fee-bump/batch  count=%d  submit=%s", len(xdrs), submit)
+            responses = [
+                {
+                    "xdr": _MOCK_FEE_BUMP_XDR,
+                    "status": "submitted" if submit else "ready",
+                    "hash": f"{_MOCK_HASH[:-2]}{i:02d}",
+                    "fee_payer": _FEE_PAYER,
+                }
+                for i, _ in enumerate(xdrs)
+            ]
+            self._send_json(200, responses)
+
+        else:
+            self._send_json(404, {"error": f"unknown path: {self.path}"})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Mock Fluid fee-bump server")
+    parser.add_argument("--port", type=int, default=3000)
+    args = parser.parse_args()
+
+    server = HTTPServer(("127.0.0.1", args.port), FluidMockHandler)
+    log.info("Mock Fluid server listening on http://127.0.0.1:%d", args.port)
+    log.info("Endpoints: POST /fee-bump  |  POST /fee-bump/batch")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/fluid-py/fluid_py/__init__.py
+++ b/fluid-py/fluid_py/__init__.py
@@ -1,0 +1,54 @@
+"""Fluid Python SDK — ``fluid-py``.
+
+A Pythonic client for the `Fluid <https://github.com/Stellar-Fluid/fluid>`_
+fee-sponsorship server.  Sponsor Stellar transaction fees from any Python
+app, AI agent, or backend automation script.
+
+Quick start::
+
+    from fluid_py import FluidClient, FluidClientConfig
+
+    client = FluidClient(
+        FluidClientConfig(
+            server_url="https://fluid.example.com",
+            network_passphrase="Test SDF Network ; September 2015",
+        )
+    )
+    response = client.request_fee_bump("<inner-transaction-xdr>")
+    print(response.xdr)
+"""
+
+from fluid_py.client import FluidClient, TransactionInput, XdrSerializable
+from fluid_py.exceptions import (
+    FluidConfigError,
+    FluidError,
+    FluidNoAvailableServerError,
+    FluidRequestError,
+    FluidSerializationError,
+)
+from fluid_py.models import (
+    FeeBumpBatchRequest,
+    FeeBumpRequest,
+    FeeBumpResponse,
+    FluidClientConfig,
+)
+
+__version__ = "0.1.0"
+__all__ = [
+    # Client
+    "FluidClient",
+    # Config + models
+    "FluidClientConfig",
+    "FeeBumpResponse",
+    "FeeBumpRequest",
+    "FeeBumpBatchRequest",
+    # Protocols
+    "XdrSerializable",
+    "TransactionInput",
+    # Exceptions
+    "FluidError",
+    "FluidRequestError",
+    "FluidConfigError",
+    "FluidSerializationError",
+    "FluidNoAvailableServerError",
+]

--- a/fluid-py/fluid_py/client.py
+++ b/fluid-py/fluid_py/client.py
@@ -1,0 +1,522 @@
+"""Core FluidClient implementation for the Fluid Python SDK.
+
+This module provides :class:`FluidClient`, the primary entry point for
+sponsoring Stellar transaction fees via the Fluid fee-bump server.
+
+Typical usage::
+
+    from stellar_sdk import Network, TransactionBuilder, Keypair
+
+    from fluid_py import FluidClient, FluidClientConfig
+
+    config = FluidClientConfig(
+        server_url="https://fluid.example.com",
+        network_passphrase=Network.TESTNET_NETWORK_PASSPHRASE,
+    )
+    client = FluidClient(config)
+
+    # Pass an XDR string or a stellar_sdk TransactionEnvelope
+    response = client.request_fee_bump(xdr)
+    print(response.xdr)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Protocol, Sequence, Union, runtime_checkable
+
+import requests
+
+from fluid_py.exceptions import (
+    FluidNoAvailableServerError,
+    FluidRequestError,
+    FluidSerializationError,
+)
+from fluid_py.models import (
+    FeeBumpBatchRequest,
+    FeeBumpRequest,
+    FeeBumpResponse,
+    FluidClientConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Type alias for transaction inputs
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class XdrSerializable(Protocol):
+    """Protocol for objects that can be serialised to an XDR string.
+
+    Both :class:`stellar_sdk.Transaction` and
+    :class:`stellar_sdk.TransactionEnvelope` satisfy this protocol via their
+    ``to_xdr()`` method.
+    """
+
+    def to_xdr(self) -> str:
+        """Return the Base64-encoded XDR representation of the transaction."""
+        ...
+
+
+#: Accepted transaction input types.
+TransactionInput = Union[str, XdrSerializable]
+
+# ---------------------------------------------------------------------------
+# Internal constants
+# ---------------------------------------------------------------------------
+
+_FAILED_NODE_COOLDOWN_S: float = 30.0
+_BASE_RETRY_DELAY_S: float = 0.25
+_MAX_RETRY_DELAY_S: float = 2.0
+
+_FEE_BUMP_PATH = "/fee-bump"
+_FEE_BUMP_BATCH_PATH = "/fee-bump/batch"
+
+
+# ---------------------------------------------------------------------------
+# FluidClient
+# ---------------------------------------------------------------------------
+
+
+class FluidClient:
+    """Client for interacting with the Fluid fee-bump server.
+
+    The client supports multiple server URLs with automatic failover and
+    exponential back-off so that transient outages on one node do not
+    surface as errors to the caller.
+
+    Args:
+        config: A :class:`~fluid_py.models.FluidClientConfig` instance that
+            specifies the server URL(s), network passphrase, and optional
+            Horizon endpoint.
+
+    Raises:
+        :class:`~fluid_py.exceptions.FluidConfigError`: If the config is
+            missing required fields (raised by
+            :class:`~fluid_py.models.FluidClientConfig`'s ``__post_init__``).
+
+    Example::
+
+        from fluid_py import FluidClient, FluidClientConfig
+
+        client = FluidClient(
+            FluidClientConfig(
+                server_url="https://fluid.example.com",
+                network_passphrase="Test SDF Network ; September 2015",
+            )
+        )
+        response = client.request_fee_bump("<inner-tx-xdr>")
+        print(response.xdr)
+    """
+
+    def __init__(self, config: FluidClientConfig) -> None:
+        self._server_urls: List[str] = self._normalise_server_urls(config)
+        self._network_passphrase: str = config.network_passphrase
+        self._horizon_url: Optional[str] = config.horizon_url
+        self._timeout: float = config.timeout
+
+        # Track per-node failure state: url -> (failure_count, failed_until)
+        self._node_failure_state: Dict[str, Dict[str, Any]] = {}
+
+        # Lazily-created requests.Session (shared across all requests)
+        self._session: Optional[requests.Session] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def request_fee_bump(
+        self,
+        transaction: TransactionInput,
+        submit: bool = False,
+    ) -> FeeBumpResponse:
+        """Request a fee-bump envelope for a single inner transaction.
+
+        The Fluid server wraps *transaction* in a fee-bump envelope signed
+        with its sponsorship key.  If *submit* is ``True`` the server also
+        broadcasts the envelope to the Stellar network.
+
+        Args:
+            transaction: The inner transaction as either a Base64-encoded XDR
+                string or any object that exposes a ``to_xdr() -> str`` method
+                (e.g. :class:`stellar_sdk.TransactionEnvelope`).
+            submit: When ``True`` the server will attempt to submit the
+                fee-bumped transaction immediately after wrapping it.
+
+        Returns:
+            A :class:`~fluid_py.models.FeeBumpResponse` with the wrapped XDR
+            and optional submission metadata.
+
+        Raises:
+            :class:`~fluid_py.exceptions.FluidSerializationError`: If the
+                transaction cannot be serialised to XDR.
+            :class:`~fluid_py.exceptions.FluidRequestError`: If the server
+                returns a 4xx error.
+            :class:`~fluid_py.exceptions.FluidNoAvailableServerError`: If all
+                configured servers are unreachable or return errors.
+
+        Example::
+
+            response = client.request_fee_bump(envelope, submit=True)
+            print(response.status)   # "submitted"
+            print(response.hash)
+        """
+        payload = FeeBumpRequest(
+            xdr=self._serialise(transaction),
+            submit=submit,
+        )
+        raw = self._request_with_fallback(
+            _FEE_BUMP_PATH,
+            {"xdr": payload.xdr, "submit": payload.submit},
+        )
+        return FeeBumpResponse.from_dict(raw)
+
+    def request_fee_bump_batch(
+        self,
+        transactions: Sequence[TransactionInput],
+        submit: bool = False,
+    ) -> List[FeeBumpResponse]:
+        """Request fee-bump envelopes for a batch of inner transactions.
+
+        This is more efficient than calling :meth:`request_fee_bump`
+        repeatedly when you need to sponsor multiple transactions at once.
+
+        Args:
+            transactions: A sequence of inner transactions, each as either a
+                Base64-encoded XDR string or an ``XdrSerializable`` object.
+            submit: When ``True`` the server will attempt to submit each
+                fee-bumped transaction immediately after wrapping it.
+
+        Returns:
+            A list of :class:`~fluid_py.models.FeeBumpResponse` objects, one
+            per input transaction, in the same order.
+
+        Raises:
+            :class:`~fluid_py.exceptions.FluidSerializationError`: If any
+                transaction in the batch cannot be serialised.
+            :class:`~fluid_py.exceptions.FluidRequestError`: If the server
+                returns a 4xx error.
+            :class:`~fluid_py.exceptions.FluidNoAvailableServerError`: If all
+                configured servers are unreachable or return errors.
+
+        Example::
+
+            responses = client.request_fee_bump_batch([env1, env2], submit=False)
+            for r in responses:
+                print(r.xdr)
+        """
+        payload = FeeBumpBatchRequest(
+            xdrs=[self._serialise(tx) for tx in transactions],
+            submit=submit,
+        )
+        raw_list: List[Dict[str, Any]] = self._request_with_fallback(
+            _FEE_BUMP_BATCH_PATH,
+            {"xdrs": payload.xdrs, "submit": payload.submit},
+        )
+        return [FeeBumpResponse.from_dict(item) for item in raw_list]
+
+    def submit_fee_bump_transaction(self, fee_bump_xdr: str) -> Dict[str, Any]:
+        """Submit an already fee-bumped XDR to the Stellar network via Horizon.
+
+        This method requires that *horizon_url* was set in
+        :class:`~fluid_py.models.FluidClientConfig`.
+
+        Args:
+            fee_bump_xdr: Base64-encoded XDR of a fee-bump transaction
+                envelope as returned by :meth:`request_fee_bump`.
+
+        Returns:
+            The raw JSON response from Horizon as a dictionary.
+
+        Raises:
+            :class:`~fluid_py.exceptions.FluidConfigError`: If *horizon_url*
+                was not configured.
+            :class:`~fluid_py.exceptions.FluidRequestError`: If the Horizon
+                submission fails.
+
+        Example::
+
+            response = client.request_fee_bump(inner_xdr)
+            horizon_result = client.submit_fee_bump_transaction(response.xdr)
+            print(horizon_result["hash"])
+        """
+        from fluid_py.exceptions import FluidConfigError  # local import to avoid cycle
+
+        if not self._horizon_url:
+            raise FluidConfigError(
+                "submit_fee_bump_transaction requires 'horizon_url' to be set "
+                "in FluidClientConfig."
+            )
+
+        horizon_url = self._horizon_url.rstrip("/")
+        session = self._get_session()
+
+        try:
+            resp = session.post(
+                f"{horizon_url}/transactions",
+                data={"tx": fee_bump_xdr},
+                timeout=self._timeout,
+            )
+        except requests.RequestException as exc:
+            raise FluidRequestError(
+                f"Horizon submission request failed: {exc}",
+                server_url=horizon_url,
+            ) from exc
+
+        if not resp.ok:
+            raise FluidRequestError(
+                f"Horizon submission error: {resp.status_code} {resp.reason} — {resp.text}",
+                status_code=resp.status_code,
+                server_url=horizon_url,
+            )
+
+        return resp.json()  # type: ignore[no-any-return]
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_session(self) -> requests.Session:
+        """Return (or lazily create) the shared :class:`requests.Session`."""
+        if self._session is None:
+            self._session = requests.Session()
+            self._session.headers.update({"Content-Type": "application/json"})
+        return self._session
+
+    @staticmethod
+    def _serialise(transaction: TransactionInput) -> str:
+        """Serialise *transaction* to a Base64-encoded XDR string.
+
+        Args:
+            transaction: Either a plain XDR string or an object with a
+                ``to_xdr()`` method (``stellar_sdk`` envelopes satisfy this).
+
+        Returns:
+            The Base64-encoded XDR string.
+
+        Raises:
+            :class:`~fluid_py.exceptions.FluidSerializationError`: If
+                serialisation fails.
+        """
+        if isinstance(transaction, str):
+            return transaction
+        to_xdr = getattr(transaction, "to_xdr", None)
+        if callable(to_xdr):
+            try:
+                return str(to_xdr())
+            except Exception as exc:
+                raise FluidSerializationError(
+                    f"Failed to serialise transaction to XDR: {exc}"
+                ) from exc
+        raise FluidSerializationError(
+            f"Unsupported transaction type: {type(transaction).__name__}. "
+            "Expected a str or an object with a to_xdr() method."
+        )
+
+    @staticmethod
+    def _normalise_server_urls(config: FluidClientConfig) -> List[str]:
+        """Return a deduplicated, normalised list of server URLs.
+
+        Args:
+            config: The client configuration.
+
+        Returns:
+            A non-empty list of server URL strings.
+
+        Raises:
+            ValueError: Propagated from
+                :class:`~fluid_py.models.FluidClientConfig` if no URL was
+                provided.
+        """
+        raw: List[str] = []
+        if config.server_urls:
+            raw.extend(config.server_urls)
+        elif config.server_url:
+            raw.append(config.server_url)
+
+        normalised = [u.strip().rstrip("/") for u in raw if u.strip()]
+
+        # Preserve order while deduplicating
+        seen: set[str] = set()
+        unique: List[str] = []
+        for url in normalised:
+            if url not in seen:
+                seen.add(url)
+                unique.append(url)
+
+        return unique
+
+    def _get_ordered_server_urls(self) -> List[str]:
+        """Return server URLs sorted by health: healthy nodes first.
+
+        Nodes that have recently failed are sorted to the back with a score
+        proportional to how long they still need to cool down, so the best
+        server is always tried first.
+
+        Returns:
+            A new list of server URL strings.
+        """
+        now = time.monotonic()
+
+        def _score(url: str) -> float:
+            state = self._node_failure_state.get(url)
+            if state and state["failed_until"] > now:
+                return float(1_000.0 + (state["failed_until"] - now))
+            return 0.0
+
+        return sorted(self._server_urls, key=_score)
+
+    def _mark_server_failure(self, server_url: str) -> None:
+        """Record a failure for *server_url* and set a cooldown period.
+
+        Subsequent failures increase the cooldown exponentially (up to 4×
+        the base cooldown), matching the TypeScript SDK behaviour.
+
+        Args:
+            server_url: The URL of the server that failed.
+        """
+        previous = self._node_failure_state.get(server_url, {})
+        failures: int = previous.get("failures", 0) + 1
+        multiplier = min(2 ** (failures - 1), 4)
+        self._node_failure_state[server_url] = {
+            "failures": failures,
+            "failed_until": time.monotonic() + _FAILED_NODE_COOLDOWN_S * multiplier,
+        }
+
+    def _mark_server_success(self, server_url: str) -> None:
+        """Clear the failure state for *server_url* after a successful request.
+
+        Args:
+            server_url: The URL of the server that succeeded.
+        """
+        self._node_failure_state.pop(server_url, None)
+
+    @staticmethod
+    def _retry_delay(attempt_index: int) -> float:
+        """Return the back-off delay in seconds for the given attempt index.
+
+        Args:
+            attempt_index: Zero-based attempt counter.
+
+        Returns:
+            Delay in seconds, capped at :data:`_MAX_RETRY_DELAY_S`.
+        """
+        return float(min(
+            _BASE_RETRY_DELAY_S * (2 ** attempt_index),
+            _MAX_RETRY_DELAY_S,
+        ))
+
+    def _perform_json_request(
+        self,
+        server_url: str,
+        path: str,
+        body: Dict[str, Any],
+    ) -> Any:
+        """Perform a single JSON POST to *server_url* + *path*.
+
+        Args:
+            server_url: The base URL of the Fluid server.
+            path: The API path (e.g. ``"/fee-bump"``).
+            body: The request body to send as JSON.
+
+        Returns:
+            The decoded JSON response (dict or list).
+
+        Raises:
+            :class:`~fluid_py.exceptions.FluidRequestError`: On network
+                errors or non-2xx responses.
+        """
+        session = self._get_session()
+        url = f"{server_url}{path}"
+
+        try:
+            resp = session.post(url, json=body, timeout=self._timeout)
+        except requests.RequestException as exc:
+            raise FluidRequestError(
+                f"Fluid server request failed: {exc}",
+                server_url=server_url,
+            ) from exc
+
+        if not resp.ok:
+            try:
+                error_detail = resp.json()
+                message = f"Fluid server error: {error_detail}"
+            except ValueError:
+                message = (
+                    f"Fluid server error: {resp.status_code} {resp.reason}"
+                    + (f" — {resp.text}" if resp.text else "")
+                )
+
+            raise FluidRequestError(
+                message,
+                status_code=resp.status_code,
+                server_url=server_url,
+            )
+
+        return resp.json()
+
+    def _request_with_fallback(
+        self,
+        path: str,
+        body: Dict[str, Any],
+    ) -> Any:
+        """Try each server URL in order, falling back on failure.
+
+        A 400 Bad Request error is considered a client error and is re-raised
+        immediately without trying the next server (the request itself is
+        malformed, not the server).
+
+        Args:
+            path: The API path to request.
+            body: The JSON request body.
+
+        Returns:
+            The decoded JSON response.
+
+        Raises:
+            :class:`~fluid_py.exceptions.FluidRequestError`: On 400 errors or
+                when a single server is configured and fails.
+            :class:`~fluid_py.exceptions.FluidNoAvailableServerError`: When
+                all configured servers fail.
+        """
+        ordered_urls = self._get_ordered_server_urls()
+        last_error: Optional[FluidRequestError] = None
+
+        for attempt_index, server_url in enumerate(ordered_urls):
+            try:
+                result = self._perform_json_request(server_url, path, body)
+                self._mark_server_success(server_url)
+                return result
+            except FluidRequestError as exc:
+                # 400 Bad Request: the request is malformed; no point retrying
+                if exc.status_code == 400:
+                    raise
+
+                last_error = exc
+                self._mark_server_failure(server_url)
+
+                if attempt_index < len(ordered_urls) - 1:
+                    delay = self._retry_delay(attempt_index)
+                    next_url = ordered_urls[attempt_index + 1]
+                    logger.warning(
+                        "[FluidClient] Request to %s failed (%s). "
+                        "Retrying %s on %s in %.2fs.",
+                        server_url,
+                        exc,
+                        path,
+                        next_url,
+                        delay,
+                    )
+                    time.sleep(delay)
+
+        raise FluidNoAvailableServerError(
+            f"All Fluid servers exhausted for {path}. "
+            f"Last error: {last_error}",
+            server_url=ordered_urls[-1] if ordered_urls else None,
+        ) from last_error
+
+    def __repr__(self) -> str:
+        urls = ", ".join(self._server_urls)
+        return f"FluidClient(server_urls=[{urls}])"

--- a/fluid-py/fluid_py/exceptions.py
+++ b/fluid-py/fluid_py/exceptions.py
@@ -1,0 +1,49 @@
+"""Custom exceptions for the Fluid Python SDK."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class FluidError(Exception):
+    """Base exception for all Fluid SDK errors."""
+
+
+class FluidRequestError(FluidError):
+    """Raised when an HTTP request to the Fluid server fails.
+
+    Args:
+        message: Human-readable error description.
+        status_code: HTTP status code returned by the server, if any.
+        server_url: The server URL that produced the error.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        status_code: Optional[int] = None,
+        server_url: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.server_url = server_url
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}("
+            f"message={str(self)!r}, "
+            f"status_code={self.status_code!r}, "
+            f"server_url={self.server_url!r})"
+        )
+
+
+class FluidConfigError(FluidError):
+    """Raised when the :class:`~fluid_py.models.FluidClientConfig` is invalid."""
+
+
+class FluidSerializationError(FluidError):
+    """Raised when a transaction cannot be serialised to XDR."""
+
+
+class FluidNoAvailableServerError(FluidRequestError):
+    """Raised when all configured servers are unavailable or exhausted."""

--- a/fluid-py/fluid_py/models.py
+++ b/fluid-py/fluid_py/models.py
@@ -1,0 +1,126 @@
+"""Data models for the Fluid Python SDK.
+
+All models use :mod:`dataclasses` with :mod:`typing` annotations so that
+they work seamlessly with ``mypy --strict`` and static analysis tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class FluidClientConfig:
+    """Configuration for :class:`~fluid_py.client.FluidClient`.
+
+    At least one of *server_url* or *server_urls* must be provided.
+
+    Args:
+        network_passphrase: Stellar network passphrase, e.g.
+            ``"Test SDF Network ; September 2015"`` or
+            ``"Public Global Stellar Network ; September 2015"``.
+        server_url: Base URL of a single Fluid fee-bump server.
+        server_urls: Base URLs of multiple Fluid fee-bump servers.
+            When more than one URL is supplied the client will try each in
+            order, applying exponential back-off on failure.
+        horizon_url: Optional Horizon API URL used by
+            :meth:`~fluid_py.client.FluidClient.submit_fee_bump_transaction`.
+        timeout: HTTP request timeout in seconds (default ``30``).
+
+    Raises:
+        ValueError: If neither *server_url* nor *server_urls* is provided.
+
+    Example::
+
+        config = FluidClientConfig(
+            server_url="https://fluid.example.com",
+            network_passphrase="Test SDF Network ; September 2015",
+        )
+    """
+
+    network_passphrase: str
+    server_url: Optional[str] = None
+    server_urls: Optional[List[str]] = None
+    horizon_url: Optional[str] = None
+    timeout: float = 30.0
+
+    def __post_init__(self) -> None:
+        if not self.server_url and not self.server_urls:
+            raise ValueError(
+                "FluidClientConfig requires at least one server URL via "
+                "'server_url' or 'server_urls'."
+            )
+
+
+@dataclass(frozen=True)
+class FeeBumpResponse:
+    """Response returned by the Fluid fee-bump endpoint.
+
+    Args:
+        xdr: Base64-encoded XDR of the fee-bumped transaction envelope.
+        status: Either ``"ready"`` (wrapped but not submitted) or
+            ``"submitted"`` (already broadcast to the Stellar network).
+        hash: Transaction hash of the fee-bump envelope (may be absent when
+            the server returns a minimal response).
+        fee_payer: Public key of the account that sponsored the fee.
+        submitted_via: Which submission path was used (e.g. ``"horizon"``).
+        submission_attempts: Number of submission attempts made by the server.
+    """
+
+    xdr: str
+    status: str
+    hash: Optional[str] = None
+    fee_payer: Optional[str] = None
+    submitted_via: Optional[str] = None
+    submission_attempts: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "FeeBumpResponse":  # type: ignore[type-arg]
+        """Construct a :class:`FeeBumpResponse` from a raw JSON dictionary.
+
+        Unknown keys are silently ignored so that future server versions
+        remain backwards-compatible.
+
+        Args:
+            data: Dictionary decoded from the server JSON response.
+
+        Returns:
+            A new :class:`FeeBumpResponse` instance.
+        """
+        return cls(
+            xdr=data["xdr"],
+            status=data["status"],
+            hash=data.get("hash"),
+            fee_payer=data.get("fee_payer"),
+            submitted_via=data.get("submitted_via"),
+            submission_attempts=data.get("submission_attempts"),
+        )
+
+
+@dataclass(frozen=True)
+class FeeBumpRequest:
+    """Serialised body for a single fee-bump request.
+
+    Args:
+        xdr: Base64-encoded XDR of the inner transaction to be fee-bumped.
+        submit: When ``True`` the server will attempt to submit the
+            fee-bumped transaction to the Stellar network immediately.
+    """
+
+    xdr: str
+    submit: bool = False
+
+
+@dataclass(frozen=True)
+class FeeBumpBatchRequest:
+    """Serialised body for a batched fee-bump request.
+
+    Args:
+        xdrs: List of Base64-encoded XDR transaction envelopes.
+        submit: When ``True`` the server will attempt to submit each
+            fee-bumped transaction to the Stellar network immediately.
+    """
+
+    xdrs: List[str] = field(default_factory=list)
+    submit: bool = False

--- a/fluid-py/pyproject.toml
+++ b/fluid-py/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fluid-py"
+version = "0.1.0"
+description = "Python client for the Fluid fee-sponsorship API — sponsor Stellar transaction fees from any Python app or AI agent."
+authors = [{ name = "Stellar-Fluid", email = "dev@fluid.dev" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.9"
+keywords = ["stellar", "soroban", "fee-bump", "gasless", "blockchain"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+dependencies = [
+    "requests>=2.28.0",
+]
+
+[project.optional-dependencies]
+stellar = ["stellar-sdk>=10.0.0"]
+dev = [
+    "pytest>=7.4",
+    "pytest-mock>=3.12",
+    "mypy>=1.8",
+    "ruff>=0.3",
+    "requests-mock>=1.11",
+    "stellar-sdk>=10.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/Stellar-Fluid/fluid"
+Documentation = "https://docs.fluid.dev/sdk/python"
+Repository = "https://github.com/Stellar-Fluid/fluid"
+"Bug Tracker" = "https://github.com/Stellar-Fluid/fluid/issues"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["fluid_py*"]
+
+[tool.mypy]
+python_version = "3.9"
+strict = true
+ignore_missing_imports = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]

--- a/fluid-py/tests/__init__.py
+++ b/fluid-py/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests/__init__.py

--- a/fluid-py/tests/test_client.py
+++ b/fluid-py/tests/test_client.py
@@ -1,0 +1,376 @@
+"""Unit tests for fluid_py.client.FluidClient.
+
+Run with::
+
+    cd fluid-py
+    pip install -e ".[dev]"
+    pytest -v
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from fluid_py import (
+    FeeBumpResponse,
+    FluidClient,
+    FluidClientConfig,
+    FluidConfigError,
+    FluidNoAvailableServerError,
+    FluidRequestError,
+    FluidSerializationError,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+DUMMY_XDR = "AAAAAQ=="  # minimal valid-looking XDR placeholder
+TEST_SERVER = "https://fluid.test"
+TEST_PASSPHRASE = "Test SDF Network ; September 2015"
+
+
+def _make_client(
+    server_url: str = TEST_SERVER,
+    server_urls: list[str] | None = None,
+    horizon_url: str | None = None,
+) -> FluidClient:
+    """Return a FluidClient configured for testing."""
+    return FluidClient(
+        FluidClientConfig(
+            server_url=server_url if server_urls is None else None,
+            server_urls=server_urls,
+            network_passphrase=TEST_PASSPHRASE,
+            horizon_url=horizon_url,
+        )
+    )
+
+
+def _fee_bump_payload(status: str = "ready", **extra: Any) -> Dict[str, Any]:
+    """Return a minimal fee-bump server response payload."""
+    return {
+        "xdr": DUMMY_XDR,
+        "status": status,
+        "hash": "abc123",
+        **extra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# FluidClientConfig
+# ---------------------------------------------------------------------------
+
+
+class TestFluidClientConfig:
+    def test_requires_server_url(self) -> None:
+        with pytest.raises(ValueError, match="at least one server URL"):
+            FluidClientConfig(network_passphrase=TEST_PASSPHRASE)
+
+    def test_accepts_single_url(self) -> None:
+        cfg = FluidClientConfig(
+            server_url=TEST_SERVER,
+            network_passphrase=TEST_PASSPHRASE,
+        )
+        assert cfg.server_url == TEST_SERVER
+
+    def test_accepts_multiple_urls(self) -> None:
+        cfg = FluidClientConfig(
+            server_urls=[TEST_SERVER, "https://fluid2.test"],
+            network_passphrase=TEST_PASSPHRASE,
+        )
+        assert cfg.server_urls is not None
+        assert len(cfg.server_urls) == 2
+
+    def test_default_timeout(self) -> None:
+        cfg = FluidClientConfig(
+            server_url=TEST_SERVER,
+            network_passphrase=TEST_PASSPHRASE,
+        )
+        assert cfg.timeout == 30.0
+
+
+# ---------------------------------------------------------------------------
+# FluidClient construction
+# ---------------------------------------------------------------------------
+
+
+class TestFluidClientInit:
+    def test_normalises_trailing_slash(self) -> None:
+        client = _make_client(server_url="https://fluid.test/")
+        assert client._server_urls == ["https://fluid.test"]
+
+    def test_deduplicates_urls(self) -> None:
+        client = _make_client(
+            server_urls=[TEST_SERVER, TEST_SERVER, "https://fluid2.test"]
+        )
+        assert len(client._server_urls) == 2
+
+    def test_repr(self) -> None:
+        client = _make_client()
+        assert "FluidClient" in repr(client)
+        assert TEST_SERVER in repr(client)
+
+
+# ---------------------------------------------------------------------------
+# _serialise
+# ---------------------------------------------------------------------------
+
+
+class TestSerialise:
+    def test_passthrough_string(self) -> None:
+        assert FluidClient._serialise(DUMMY_XDR) == DUMMY_XDR
+
+    def test_calls_to_xdr(self) -> None:
+        mock_tx = MagicMock()
+        mock_tx.to_xdr.return_value = DUMMY_XDR
+        result = FluidClient._serialise(mock_tx)
+        assert result == DUMMY_XDR
+        mock_tx.to_xdr.assert_called_once()
+
+    def test_to_xdr_exception_raises_serialisation_error(self) -> None:
+        mock_tx = MagicMock()
+        mock_tx.to_xdr.side_effect = RuntimeError("broken")
+        with pytest.raises(FluidSerializationError, match="Failed to serialise"):
+            FluidClient._serialise(mock_tx)
+
+    def test_unsupported_type_raises_error(self) -> None:
+        with pytest.raises(FluidSerializationError, match="Unsupported transaction type"):
+            FluidClient._serialise(12345)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# request_fee_bump
+# ---------------------------------------------------------------------------
+
+
+class TestRequestFeeBump:
+    def test_successful_fee_bump(self, requests_mock: Any) -> None:
+        requests_mock.post(
+            f"{TEST_SERVER}/fee-bump",
+            json=_fee_bump_payload(),
+        )
+        client = _make_client()
+        response = client.request_fee_bump(DUMMY_XDR)
+
+        assert isinstance(response, FeeBumpResponse)
+        assert response.xdr == DUMMY_XDR
+        assert response.status == "ready"
+        assert response.hash == "abc123"
+
+    def test_passes_submit_flag(self, requests_mock: Any) -> None:
+        adapter = requests_mock.post(
+            f"{TEST_SERVER}/fee-bump",
+            json=_fee_bump_payload(status="submitted"),
+        )
+        client = _make_client()
+        response = client.request_fee_bump(DUMMY_XDR, submit=True)
+
+        assert response.status == "submitted"
+        sent_body = json.loads(adapter.last_request.body)
+        assert sent_body["submit"] is True
+
+    def test_uses_xdr_serializable_input(self, requests_mock: Any) -> None:
+        requests_mock.post(f"{TEST_SERVER}/fee-bump", json=_fee_bump_payload())
+        mock_tx = MagicMock()
+        mock_tx.to_xdr.return_value = DUMMY_XDR
+
+        client = _make_client()
+        client.request_fee_bump(mock_tx)
+        mock_tx.to_xdr.assert_called_once()
+
+    def test_400_raises_without_fallback(self, requests_mock: Any) -> None:
+        requests_mock.post(
+            f"{TEST_SERVER}/fee-bump",
+            status_code=400,
+            json={"error": "bad xdr"},
+        )
+        client = _make_client()
+        with pytest.raises(FluidRequestError) as exc_info:
+            client.request_fee_bump(DUMMY_XDR)
+        assert exc_info.value.status_code == 400
+
+    def test_500_marks_failure_and_raises(self, requests_mock: Any) -> None:
+        requests_mock.post(
+            f"{TEST_SERVER}/fee-bump",
+            status_code=503,
+            text="service unavailable",
+        )
+        client = _make_client()
+        with pytest.raises(FluidNoAvailableServerError):
+            client.request_fee_bump(DUMMY_XDR)
+        assert TEST_SERVER in client._node_failure_state
+
+    def test_network_error_raises_no_available_server_error(
+        self, requests_mock: Any
+    ) -> None:
+        requests_mock.post(
+            f"{TEST_SERVER}/fee-bump",
+            exc=requests.ConnectionError("connection refused"),
+        )
+        client = _make_client()
+        with pytest.raises(FluidNoAvailableServerError):
+            client.request_fee_bump(DUMMY_XDR)
+
+
+# ---------------------------------------------------------------------------
+# Multi-server failover
+# ---------------------------------------------------------------------------
+
+
+class TestMultiServerFailover:
+    def test_falls_back_to_second_server(self, requests_mock: Any) -> None:
+        server1 = "https://fluid1.test"
+        server2 = "https://fluid2.test"
+
+        requests_mock.post(f"{server1}/fee-bump", status_code=503, text="down")
+        requests_mock.post(f"{server2}/fee-bump", json=_fee_bump_payload())
+
+        client = _make_client(server_urls=[server1, server2])
+
+        with patch("time.sleep"):  # skip back-off delays in tests
+            response = client.request_fee_bump(DUMMY_XDR)
+
+        assert response.xdr == DUMMY_XDR
+        # server1 should be marked as failed
+        assert server1 in client._node_failure_state
+
+    def test_raises_when_all_servers_fail(self, requests_mock: Any) -> None:
+        server1 = "https://fluid1.test"
+        server2 = "https://fluid2.test"
+
+        requests_mock.post(f"{server1}/fee-bump", status_code=503, text="down")
+        requests_mock.post(f"{server2}/fee-bump", status_code=503, text="down")
+
+        client = _make_client(server_urls=[server1, server2])
+
+        with patch("time.sleep"):
+            with pytest.raises(FluidNoAvailableServerError):
+                client.request_fee_bump(DUMMY_XDR)
+
+
+# ---------------------------------------------------------------------------
+# request_fee_bump_batch
+# ---------------------------------------------------------------------------
+
+
+class TestRequestFeeBumpBatch:
+    def test_batch_returns_list(self, requests_mock: Any) -> None:
+        requests_mock.post(
+            f"{TEST_SERVER}/fee-bump/batch",
+            json=[_fee_bump_payload(), _fee_bump_payload(hash="def456")],
+        )
+        client = _make_client()
+        responses = client.request_fee_bump_batch([DUMMY_XDR, DUMMY_XDR])
+
+        assert len(responses) == 2
+        assert isinstance(responses[0], FeeBumpResponse)
+        assert responses[1].hash == "def456"
+
+    def test_batch_sends_correct_body(self, requests_mock: Any) -> None:
+        adapter = requests_mock.post(
+            f"{TEST_SERVER}/fee-bump/batch",
+            json=[_fee_bump_payload()],
+        )
+        client = _make_client()
+        client.request_fee_bump_batch([DUMMY_XDR])
+
+        body = json.loads(adapter.last_request.body)
+        assert body["xdrs"] == [DUMMY_XDR]
+        assert body["submit"] is False
+
+
+# ---------------------------------------------------------------------------
+# submit_fee_bump_transaction
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitFeeBumpTransaction:
+    def test_raises_without_horizon_url(self) -> None:
+        client = _make_client()
+        with pytest.raises(FluidConfigError, match="horizon_url"):
+            client.submit_fee_bump_transaction(DUMMY_XDR)
+
+    def test_posts_to_horizon(self, requests_mock: Any) -> None:
+        horizon = "https://horizon-testnet.stellar.org"
+        requests_mock.post(
+            f"{horizon}/transactions",
+            json={"hash": "abc", "ledger": 1},
+        )
+        client = _make_client(horizon_url=horizon)
+        result = client.submit_fee_bump_transaction(DUMMY_XDR)
+        assert result["hash"] == "abc"
+
+    def test_horizon_error_raises_fluid_request_error(
+        self, requests_mock: Any
+    ) -> None:
+        horizon = "https://horizon-testnet.stellar.org"
+        requests_mock.post(
+            f"{horizon}/transactions",
+            status_code=400,
+            json={"title": "Transaction Failed"},
+        )
+        client = _make_client(horizon_url=horizon)
+        with pytest.raises(FluidRequestError) as exc_info:
+            client.submit_fee_bump_transaction(DUMMY_XDR)
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Failure-state helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNodeFailureState:
+    def test_mark_failure_increments_count(self) -> None:
+        client = _make_client()
+        client._mark_server_failure(TEST_SERVER)
+        assert client._node_failure_state[TEST_SERVER]["failures"] == 1
+
+        client._mark_server_failure(TEST_SERVER)
+        assert client._node_failure_state[TEST_SERVER]["failures"] == 2
+
+    def test_mark_success_clears_state(self) -> None:
+        client = _make_client()
+        client._mark_server_failure(TEST_SERVER)
+        client._mark_server_success(TEST_SERVER)
+        assert TEST_SERVER not in client._node_failure_state
+
+    def test_retry_delay_caps_at_max(self) -> None:
+        from fluid_py.client import _MAX_RETRY_DELAY_S
+
+        large_delay = FluidClient._retry_delay(100)
+        assert large_delay == _MAX_RETRY_DELAY_S
+
+
+# ---------------------------------------------------------------------------
+# FeeBumpResponse
+# ---------------------------------------------------------------------------
+
+
+class TestFeeBumpResponse:
+    def test_from_dict_minimal(self) -> None:
+        r = FeeBumpResponse.from_dict({"xdr": DUMMY_XDR, "status": "ready"})
+        assert r.xdr == DUMMY_XDR
+        assert r.status == "ready"
+        assert r.hash is None
+
+    def test_from_dict_full(self) -> None:
+        r = FeeBumpResponse.from_dict(
+            {
+                "xdr": DUMMY_XDR,
+                "status": "submitted",
+                "hash": "xyz",
+                "fee_payer": "GABC",
+                "submitted_via": "horizon",
+                "submission_attempts": 1,
+                "unknown_future_field": "ignored",
+            }
+        )
+        assert r.hash == "xyz"
+        assert r.fee_payer == "GABC"
+        assert r.submission_attempts == 1


### PR DESCRIPTION
# Fluid Python SDK (fluid-py)

## Description

This PR introduces `fluid-py`, a dedicated Python library for interacting with a Fluid fee-bump server. It enables Python-based AI agents and backend automation scripts to sponsor Stellar transaction fees with a simple, type-safe interface.

## Changes

- **Package structure**: `pip`-installable package with `pyproject.toml` following modern Python standards
- **FluidClient class**: Core client with `request_fee_bump`, batch fee-bump support, and Horizon submit helpers
- **Type safety**: Comprehensive type hints and `mypy`-strict compatibility
- **Error handling**: Custom exception hierarchy for clear failure modes
- **Documentation**: Full docstrings on all public methods
- **Examples**: Working demo script with local mock fee-bump server
- **Tests**: Test suite covering serialization, failover, request flow, and error handling

## Files Added
```
fluid-py/
├── pyproject.toml
├── fluid_py/
│ ├── init.py
│ ├── client.py # FluidClient main implementation
│ ├── exceptions.py # Custom error types
│ └── models.py # Typed request/response models
├── examples/
│ ├── example_fee_bump.py
│ └── mock_fluid_server.py
└── tests/
├── init.py
└── test_client.py
```


## Evidence

**Successful execution proof:**
---
<img width="1305" height="474" alt="Screenshot from 2026-04-23 06-42-23" src="https://github.com/user-attachments/assets/08c41c44-d9e2-431b-b3d4-edb11abf8265" />

---


**Verification:**
- `pip install -e .` ✅ installs successfully
- `mypy fluid_py` ✅ passes strict type checking
- `pytest tests/` ✅ all tests pass
- Example script runs end-to-end with mock server ✅

Closes #113