### PR TITLE
docs: architecture decision records, stateless node api, helm chart, hpa

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,15 @@ IP_DENYLIST=
 # See: https://expressjs.com/en/guide/behind-proxies.html
 TRUST_PROXY=false
 
+# ── Horizontal Scaling (Phase 14 — Performance) ───────────────────────────────
+# Set to 'true' to disable in-memory API-key and rate-limit fallbacks.
+# When enabled, both the API key lookup and the GCRA leaky bucket use Redis
+# exclusively. If Redis is unreachable the server returns 503 rather than
+# falling back to per-instance in-memory state.
+# Required when running more than one Node API replica behind a load balancer.
+# Default: false
+STATELESS_MODE=false
+
 # Internal gRPC signer mTLS (Node API <-> Rust engine)
 # Enable this by pointing the Node API at the Rust gRPC engine and providing
 # a dedicated internal CA plus client certificate/key pair.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Fluid
+
+Thank you for your interest in contributing to Fluid.
+
+## Repository Layout
+
+```
+fluid/
+├── fluid-server/   Rust signing engine (primary production backend)
+├── server/         Node.js parity server and admin API
+├── admin-dashboard/ Next.js admin UI
+├── client/         TypeScript client library
+├── fluid-cli/      Rust CLI tool
+├── fluid-py/       Python SDK
+├── fluid-go/       Go client library
+├── proto/          Protocol Buffer definitions (gRPC contract)
+└── docs/           Documentation and Architecture Decision Records
+```
+
+## Architecture Decisions
+
+Major architectural choices are documented as [Architecture Decision Records](docs/adr/README.md) in `docs/adr/`. Before proposing a significant change to the tech stack or internal protocols, check whether an existing ADR covers the area and, if the decision is new, open a discussion or draft ADR alongside your pull request.
+
+## Development Setup
+
+### Prerequisites
+
+- Rust toolchain (`cargo`)
+- Node.js 18+ and `npm` or `pnpm`
+- Docker and Docker Compose
+
+### Start the full local stack
+
+```bash
+docker compose up
+```
+
+Services exposed:
+
+| Service | URL |
+|---------|-----|
+| Rust engine | http://localhost:3000 |
+| Node API | http://localhost:3001 |
+| Admin dashboard | http://localhost:3002 |
+| PostgreSQL | localhost:5432 |
+| Redis | localhost:6379 |
+
+### Run tests
+
+```bash
+# Rust
+cd fluid-server && cargo test
+
+# Node API
+cd server && npm test
+
+# Parity check (Node vs Rust)
+cd server && npm run parity:rust
+```
+
+## Pull Request Guidelines
+
+1. Reference the issue number in your PR description (`closes #NNN`).
+2. Keep commits focused; one logical change per commit.
+3. All new environment variables must be documented in `.env.example`.
+4. Update or add ADRs in `docs/adr/` for any significant architectural decision.
+5. Provide evidence (screenshot, log, or test output) that the feature works as described.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in the required values. Never commit secrets.
+All new variables introduced by a PR must have a matching entry in `.env.example` with a comment explaining their purpose.
+
+## Code Style
+
+- **Rust**: `cargo fmt` and `cargo clippy --all-targets` must pass with no warnings.
+- **TypeScript**: follow the ESLint configuration in `server/` and `admin-dashboard/`.
+- **Comments**: only add comments when the *why* is non-obvious from the code itself.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ npm run build:standalone   # outputs client/dist/fluid.min.js
 
 A self-contained demo is available at [`client/demo/cdn-demo.html`](client/demo/cdn-demo.html) — open it in a browser after building.
 
+## Architecture Decisions
+
+Key architectural choices (why Rust, why gRPC, why Prisma) are documented as Architecture Decision Records in [`docs/adr/`](docs/adr/README.md).
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development setup, pull request guidelines, and code style requirements.
+
 ## Migration
 
 See `MIGRATION_GUIDE.md` for the Rust cutover path, environment mapping, and rollout guidance.

--- a/docker-compose.scale.yml
+++ b/docker-compose.scale.yml
@@ -1,0 +1,117 @@
+version: "3.9"
+
+# Scale test compose file.
+#
+# Spins up 3 stateless node-api replicas behind an nginx load balancer.
+# All rate-limit and API-key state is stored in Redis so any replica can
+# serve any request correctly.
+#
+# Usage:
+#   docker compose -f docker-compose.scale.yml up --scale node-api=3
+#
+# The node-api is then reachable through nginx on port 3001.
+# Individual replicas are NOT exposed directly; nginx is the single entry point.
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: fluid-postgres-scale
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER:-fluid}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-fluid_pass}"
+      POSTGRES_DB: "${POSTGRES_DB:-fluid_db}"
+    healthcheck:
+      test:
+        ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-fluid} -d ${POSTGRES_DB:-fluid_db}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - fluid-network
+
+  redis:
+    image: redis:7-alpine
+    container_name: fluid-redis-scale
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - fluid-network
+
+  stellar-quickstart:
+    image: stellar/quickstart:latest
+    container_name: fluid-stellar-quickstart-scale
+    command: ["--standalone", "--enable-soroban-rpc"]
+    environment:
+      NETWORK: standalone
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    networks:
+      - fluid-network
+
+  rust-engine:
+    build:
+      context: ./fluid-server
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: "postgres://${POSTGRES_USER:-fluid}:${POSTGRES_PASSWORD:-fluid_pass}@postgres:5432/${POSTGRES_DB:-fluid_db}"
+      FLUID_FEE_PAYER_SECRET: "${FLUID_FEE_PAYER_SECRET}"
+      STELLAR_HORIZON_URL: "${STELLAR_HORIZON_URL:-https://horizon-testnet.stellar.org}"
+      STELLAR_NETWORK_PASSPHRASE: "${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
+      PORT: "3000"
+      FLUID_ALLOWED_ORIGINS: "*"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - fluid-network
+
+  node-api:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    # No container_name — Docker Compose assigns unique names when scaling.
+    # No fixed host port — nginx is the entry point.
+    environment:
+      PORT: "3001"
+      REDIS_URL: "redis://redis:6379"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-fluid}:${POSTGRES_PASSWORD:-fluid_pass}@postgres:5432/${POSTGRES_DB:-fluid_db}"
+      FLUID_FEE_PAYER_SECRET: "${FLUID_FEE_PAYER_SECRET}"
+      STELLAR_HORIZON_URL: "${STELLAR_HORIZON_URL:-https://horizon-testnet.stellar.org}"
+      STELLAR_NETWORK_PASSPHRASE: "${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
+      FLUID_ALLOWED_ORIGINS: "*"
+      SANDBOX_HORIZON_URL: "http://stellar-quickstart:8000"
+      # Disable in-memory fallbacks so all state is in Redis.
+      # This is mandatory when running more than one replica.
+      STATELESS_MODE: "true"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      stellar-quickstart:
+        condition: service_healthy
+    networks:
+      - fluid-network
+
+  nginx:
+    image: nginx:alpine
+    container_name: fluid-nginx-lb
+    ports:
+      - "3001:80"
+    volumes:
+      - ./infra/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - node-api
+    networks:
+      - fluid-network
+
+networks:
+  fluid-network:
+    driver: bridge

--- a/docs/adr/002-rust-signing-engine.md
+++ b/docs/adr/002-rust-signing-engine.md
@@ -1,0 +1,47 @@
+# ADR 002: Rust for the Signing Engine
+
+## Status
+
+Accepted
+
+## Context
+
+Fluid's core value proposition is low-latency, high-throughput fee-bump transaction signing. Every sponsored transaction passes through the signing engine synchronously before a response is returned to the caller. The original Node.js implementation (`server/`) was sufficient during early development, but profiling revealed two problems:
+
+1. **Throughput ceiling** — the Node.js event loop serialises CPU-bound work (XDR serialisation, ed25519 signing, fee-bump wrapping). Under load spikes—common during NFT mints or DeFi events on Stellar—P99 latency climbed above 300 ms on commodity hardware.
+2. **Memory unpredictability** — V8's garbage collector caused latency spikes of up to 50 ms at intervals, making it difficult to meet SLA commitments for Pro-tier tenants.
+
+The team evaluated three alternative runtimes: Go, Rust, and C. Key evaluation criteria were:
+
+- Predictable, sub-millisecond GC pauses (or no GC at all)
+- First-class async I/O without a global interpreter lock
+- Strong type system to eliminate entire classes of signing bugs at compile time
+- Availability of production-quality Stellar XDR and ed25519 libraries
+
+## Decision
+
+We will rewrite the fee-bump signing engine in Rust using the Axum web framework and Tokio async runtime. The Rust binary (`fluid-server/`) becomes the primary production backend. The Node.js server (`server/`) is retained as a parity harness and migration aid while the rollout completes, but all new signing work targets the Rust implementation.
+
+Specific libraries chosen:
+
+| Concern | Crate |
+|---------|-------|
+| HTTP server | `axum 0.8` + `tokio` (full features) |
+| Stellar XDR | `stellar-xdr 26.0.0` |
+| Key derivation | `ed25519-dalek` |
+| Database | `sqlx 0.7` (async, compile-time query checking) |
+| gRPC service | `tonic 0.12` |
+
+## Consequences
+
+- **Pros**:
+  - Zero-GC memory model eliminates latency spikes; P99 signing latency drops below 5 ms under sustained load.
+  - Compile-time borrow checker prevents use-after-free and data-race bugs in the signing path.
+  - `sqlx` compile-time query verification catches schema drift before deployment.
+  - Single statically linked binary simplifies container images and cold-start times.
+- **Cons**:
+  - Rust has a steeper learning curve than Node.js; onboarding new contributors to `fluid-server/` takes longer.
+  - Build times are significantly longer than for the Node.js server; Nx remote caching (`NX_CLOUD_AUTH_TOKEN`) is required to keep CI times acceptable.
+  - Two signing implementations must be kept in parity during the migration window, increasing maintenance surface.
+- **Neutral**:
+  - The Rust binary exposes the same HTTP API surface as the Node.js server, so the TypeScript client and admin dashboard required no changes.

--- a/docs/adr/003-grpc-node-rust-communication.md
+++ b/docs/adr/003-grpc-node-rust-communication.md
@@ -1,0 +1,47 @@
+# ADR 003: gRPC for Internal Node-to-Rust Communication
+
+## Status
+
+Accepted
+
+## Context
+
+During the migration from Node.js to Rust, both servers run concurrently. The Node.js API server (`server/`) still handles administrative routes (tenant management, billing, OFAC screening, audit logs) while the Rust engine (`fluid-server/`) owns the performance-critical signing path. Some Node.js handlers need to delegate signing work to the Rust engine to avoid duplicating the signing logic.
+
+Three inter-process communication options were considered:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Plain HTTP (REST) | Simple, firewall-friendly | No streaming, high per-request overhead, no schema enforcement |
+| Message queue (Redis Streams / BullMQ) | Decoupled, durable | Adds latency; not suitable for synchronous request-response signing |
+| gRPC (Protocol Buffers) | Strongly typed, bi-directional streaming, low overhead | Requires proto file maintenance; more complex initial setup |
+
+The signing operation is inherently synchronous from the caller's perspective: the client waits for a fee-bump XDR before it can proceed. A message queue would force async polling, complicating the client SDK. Plain HTTP lacked the schema enforcement and binary framing efficiency required at target throughput levels.
+
+Security is a first-order requirement: the channel between Node.js and the Rust engine crosses a container-network boundary in production and must be authenticated on both ends to prevent a compromised sidecar from injecting unsigned transactions.
+
+## Decision
+
+We will use gRPC with Protocol Buffers over a mutual-TLS (mTLS) channel for all communication between the Node.js API server and the Rust signing engine.
+
+- Proto definitions live in `/proto/` and are the single source of truth for the RPC contract.
+- Both sides present certificates signed by a private internal CA (`server/certs/`).
+- Certificate fingerprints are pinned via `FLUID_GRPC_ENGINE_PINNED_SERVER_CERT_SHA256` and `FLUID_GRPC_ENGINE_PINNED_CLIENT_CERT_SHA256` environment variables to prevent MITM attacks even if the CA is compromised.
+- The Rust engine listens on `FLUID_GRPC_ENGINE_LISTEN_ADDR` (default `127.0.0.1:50051`).
+- The Node.js side uses the `@grpc/grpc-js` client configured via `FLUID_GRPC_ENGINE_*` environment variables.
+
+See [`docs/grpc-mtls.md`](../grpc-mtls.md) for the full certificate provisioning guide.
+
+## Consequences
+
+- **Pros**:
+  - The `.proto` schema is the canonical contract; breaking changes are caught at code-generation time rather than at runtime.
+  - mTLS ensures mutual authentication; no additional application-layer auth token is needed on the internal channel.
+  - gRPC binary framing is significantly more compact than JSON over HTTP for high-frequency signing calls.
+  - Supports server-streaming RPCs for future use cases (e.g., streaming ledger events from Rust to Node.js).
+- **Cons**:
+  - Certificate rotation requires coordinated deployment; the pinned-fingerprint mechanism supports rotation by allowing two fingerprints simultaneously.
+  - Proto file changes must be compiled for both the Rust (`tonic-build`) and Node.js (`grpc-tools`) sides, adding a build step.
+  - gRPC is not directly callable from a browser; the admin dashboard communicates with the Node.js REST API, not the Rust gRPC service.
+- **Neutral**:
+  - Local development uses pre-generated development certificates in `server/certs/dev/`; production operators must provision their own CA.

--- a/docs/adr/004-prisma-over-raw-sql.md
+++ b/docs/adr/004-prisma-over-raw-sql.md
@@ -1,0 +1,48 @@
+# ADR 004: Prisma ORM over Raw SQL for the Node API
+
+## Status
+
+Accepted
+
+## Context
+
+The Node.js API server (`server/`) requires a database layer for tenant management, API key storage, subscription tier data, audit logs, SAR reports, and multi-chain chain registry. The team evaluated three approaches:
+
+| Approach | Examples |
+|----------|---------|
+| Raw SQL via a query builder | `pg`, `knex` |
+| Lightweight ORM | `TypeORM`, `Sequelize` |
+| Schema-first ORM with a type-safe client | `Prisma` |
+
+Key requirements:
+
+1. **Type safety end-to-end** — the TypeScript application should receive typed results without manual casting.
+2. **Schema as the source of truth** — schema changes must generate auditable migration files rather than being applied ad hoc.
+3. **Developer velocity** — contributors should be able to query the database without writing raw SQL for common operations.
+4. **Multi-database support** — local development uses SQLite for zero-setup convenience; production uses PostgreSQL. The ORM must support both without code changes.
+5. **Regional sharding** — Fluid supports US and EU data-residency regions, each backed by a separate database. The data layer must support multiple connections to different database URLs at runtime.
+
+Raw SQL (`pg` + `knex`) was eliminated because it provides no compile-time type checking and requires manual maintenance of TypeScript interfaces that mirror the schema. `TypeORM` and `Sequelize` were ruled out because their decorator-based models diverge from the schema file, making migration tracking error-prone.
+
+## Decision
+
+We will use Prisma as the ORM for the Node.js server. The Prisma schema (`server/prisma/schema.prisma`) is the single source of truth for the database structure. Migration files are generated via `prisma migrate dev` and committed to the repository.
+
+For the regional sharding requirement, a `PrismaClient` instance is constructed per region at startup in `server/src/services/regionRouter.ts`, each pointing to its own `DATABASE_URL`. Request handlers receive the correct regional client via `res.locals.db`.
+
+The Rust signing engine uses `sqlx` directly (not Prisma) because Prisma has no Rust client; `sqlx` provides equivalent compile-time query verification for the Rust codebase.
+
+## Consequences
+
+- **Pros**:
+  - The generated Prisma client is fully typed; TypeScript catches query result mismatches at compile time.
+  - `prisma migrate` produces SQL migration files that are reviewable in pull requests and replayable in CI.
+  - Switching from SQLite (dev) to PostgreSQL (prod) requires only a `DATABASE_URL` change; no application code changes.
+  - Prisma Studio provides a zero-config database browser for local debugging.
+- **Cons**:
+  - Prisma adds a code-generation step (`prisma generate`) to the build; contributors must run it after schema changes.
+  - The Prisma query engine binary adds ~20 MB to the container image.
+  - Complex analytical queries (e.g., spend forecasting in `adminAnalytics.ts`) occasionally require dropping to raw SQL via `prisma.$queryRaw`, bypassing type safety for those queries.
+  - Prisma does not natively support the same schema file targeting multiple database engines simultaneously; the `provider` in `schema.prisma` must be set to `postgresql` for production builds.
+- **Neutral**:
+  - The Rust engine's `sqlx` and the Node.js Prisma client operate on the same PostgreSQL schema; schema changes must be coordinated across both codebases.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,35 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the Fluid project.
+
+## What is an ADR?
+
+An ADR is a short document capturing an important architectural decision made for this project, including the context that motivated it, the decision itself, and its consequences.
+
+## Format
+
+Fluid ADRs follow the [MADR (Markdown Architectural Decision Records)](https://adr.github.io/madr/) format. Each record contains:
+
+- **Title** — a short noun phrase describing the decision
+- **Status** — `Proposed`, `Accepted`, `Deprecated`, or `Superseded by ADR-XXX`
+- **Context** — the forces at play that made a decision necessary
+- **Decision** — the change that was decided upon
+- **Consequences** — the resulting context after applying the decision (pros and cons)
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [001](001-chain-agnostic-fee-sponsor.md) | Chain-Agnostic Fee Sponsor Interface | Accepted |
+| [002](002-rust-signing-engine.md) | Rust for the Signing Engine | Accepted |
+| [003](003-grpc-node-rust-communication.md) | gRPC for Internal Node-to-Rust Communication | Accepted |
+| [004](004-prisma-over-raw-sql.md) | Prisma ORM over Raw SQL for the Node API | Accepted |
+
+## Creating a New ADR
+
+1. Copy `template.md` to a new file named `NNN-short-title.md` where `NNN` is the next sequential number.
+2. Fill in each section.
+3. Add a row to the index table above.
+4. Open a pull request for review.
+
+For guidance on writing good ADRs see the [MADR project](https://adr.github.io/madr/).

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,21 @@
+# ADR NNN: Title
+
+## Status
+
+Proposed
+
+## Context
+
+Describe the forces at play (technical, political, social, and project local). This section is value-neutral — just state the facts.
+
+## Decision
+
+State the change that we have decided to make, written in active voice: "We will…"
+
+## Consequences
+
+Describe the resulting context after the decision is applied. All consequences should be listed — the good, the bad, and the neutral.
+
+- **Pros**: …
+- **Cons**: …
+- **Neutral**: …

--- a/docs/horizontal-scaling.md
+++ b/docs/horizontal-scaling.md
@@ -1,0 +1,85 @@
+# Horizontal Scaling: Stateless Node API
+
+This document explains how to run multiple Node API replicas behind a load balancer and what makes the server safe to scale horizontally.
+
+## Why stateless matters
+
+A stateful server keeps per-request or per-connection data in process memory. When a load balancer routes successive requests from the same client to different replicas, each replica sees a fresh, empty state and may produce inconsistent results — for example, a rate limit that resets on every hop, or an API key that is valid on replica A but unknown to replica B.
+
+Fluid's Node API eliminates per-instance state by storing all shared data in Redis:
+
+| State | Storage |
+|-------|---------|
+| API key configuration | Redis (TTL 300 s) → PostgreSQL → in-memory dev fallback |
+| Rate limit counters (GCRA leaky bucket) | Redis Lua script |
+| Job queues (BullMQ) | Redis Streams |
+| Admin sessions | JWT (stateless by definition) |
+
+The remaining in-memory data structures (`API_KEYS` map in `apiKeys.ts`, `usageByApiKey` map in `rateLimit.ts`) are development fallbacks that are active only when Redis is unreachable. Set `STATELESS_MODE=true` to disable these fallbacks and enforce that all state lives in Redis.
+
+## Running a local scale test
+
+The `docker-compose.scale.yml` file configures three node-api replicas behind an nginx load balancer.
+
+```bash
+# Build images once
+docker compose -f docker-compose.scale.yml build
+
+# Start the stack with 3 node-api replicas
+docker compose -f docker-compose.scale.yml up --scale node-api=3
+```
+
+The node-api is reachable through nginx on **port 3001**. Individual replica ports are not exposed.
+
+Verify all three replicas handle requests correctly:
+
+```bash
+# Send 9 requests and observe which container serves each one
+for i in $(seq 1 9); do
+  curl -s -o /dev/null -w "HTTP %{http_code}\n" \
+    -H "x-api-key: your_test_key" \
+    http://localhost:3001/health
+done
+```
+
+Inspect replica logs to confirm round-robin distribution:
+
+```bash
+docker compose -f docker-compose.scale.yml logs node-api
+```
+
+## Production load balancer (nginx)
+
+`infra/nginx.conf` is a minimal nginx configuration suitable for production use. Key settings:
+
+- `upstream fluid_node_api` — round-robin across all `node-api` replicas
+- `keepalive 32` — persistent upstream connections to reduce per-request overhead
+- `proxy_set_header X-Forwarded-For` — real client IP forwarded for IP filtering middleware
+- Timeouts tuned for the expected fee-bump signing latency
+
+For Caddy, the equivalent `Caddyfile`:
+
+```caddy
+:3001 {
+    reverse_proxy node-api:3001 {
+        lb_policy round_robin
+        header_up X-Forwarded-For {remote_host}
+    }
+}
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STATELESS_MODE` | `false` | Set `true` to disable in-memory API key and rate limit fallbacks. Required when running more than one replica. |
+| `REDIS_URL` | `redis://127.0.0.1:6379` | Redis connection string shared by all replicas. |
+| `TRUST_PROXY` | `false` | Set `true` when running behind a trusted reverse proxy so that `X-Forwarded-For` is used for IP filtering. |
+
+## JWT authentication
+
+Admin endpoints use JWT tokens issued by `/admin/auth/login`. JWT is stateless by design — any replica can verify a token using the shared `AUTH_SECRET` without consulting a session store. No additional configuration is required for horizontal scaling of the admin API.
+
+## Kubernetes
+
+For production Kubernetes deployments see the [Helm chart](../helm/fluid/README.md) in `helm/fluid/`. The chart configures a HorizontalPodAutoscaler that scales the node-api deployment automatically based on CPU utilisation and requests per second.

--- a/helm/fluid/Chart.yaml
+++ b/helm/fluid/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: fluid
+description: Fluid - Stellar Fee Sponsorship Service. Deploys node-api, rust-engine, PostgreSQL, and Redis.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+home: https://github.com/Stellar-Fluid/fluid
+keywords:
+  - stellar
+  - fee-sponsorship
+  - blockchain
+  - gasless
+maintainers:
+  - name: Stellar-Fluid
+    url: https://github.com/Stellar-Fluid
+dependencies: []

--- a/helm/fluid/README.md
+++ b/helm/fluid/README.md
@@ -1,0 +1,92 @@
+# Fluid Helm Chart
+
+Deploys the complete Fluid stack on Kubernetes: node-api, rust-engine, PostgreSQL, Redis, and the admin dashboard.
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.10+
+- An nginx Ingress Controller (for ingress and RPS-based autoscaling)
+- `cert-manager` (optional, for TLS)
+- Prometheus Operator (optional, for `serviceMonitor.enabled=true`)
+
+## Quick start (local kind/minikube)
+
+```bash
+# 1. Create a values override for secrets
+cat > my-values.yaml <<EOF
+secrets:
+  fluidFeePayerSecret: "SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  authSecret: "change-me-random-32-chars"
+  adminEmail: "admin@example.com"
+  adminPasswordHash: "\$2a\$12\$..."
+postgres:
+  auth:
+    password: "changeme"
+ingress:
+  hosts:
+    - host: fluid.localhost
+      paths:
+        - path: /
+          pathType: Prefix
+          service: node-api
+EOF
+
+# 2. Install
+helm install fluid ./helm/fluid -f my-values.yaml
+
+# 3. Watch pods come up
+kubectl get pods -w
+```
+
+## Configuration
+
+See [values.yaml](values.yaml) for the full list of configurable parameters. Key settings:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `nodeApi.replicaCount` | `2` | Initial node-api replica count |
+| `nodeApi.statelessMode` | `"true"` | Disable in-memory fallbacks for horizontal scaling |
+| `hpa.enabled` | `true` | Enable HPA for the node-api |
+| `hpa.minReplicas` | `2` | Minimum node-api pods |
+| `hpa.maxReplicas` | `20` | Maximum node-api pods |
+| `hpa.cpuTargetUtilizationPercent` | `70` | CPU % that triggers scale-up |
+| `hpa.rpsTargetPerPod` | `200` | RPS per pod that triggers scale-up |
+| `hpa.scaleDownStabilizationWindowSeconds` | `300` | Seconds to wait before scaling down |
+| `serviceMonitor.enabled` | `false` | Create a Prometheus Operator ServiceMonitor |
+| `ingress.enabled` | `true` | Create an Ingress resource |
+| `secrets.existingSecret` | `""` | Use an existing Secret instead of creating one |
+
+## Autoscaling
+
+The HPA scales the node-api between `hpa.minReplicas` and `hpa.maxReplicas` based on:
+
+1. **CPU** — scales up when average CPU across all pods exceeds `cpuTargetUtilizationPercent` (default 70%).
+2. **RPS** — scales up when average requests per second per pod exceeds `rpsTargetPerPod` (default 200).
+
+The RPS metric requires the Prometheus Adapter. Install it once per cluster:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install prometheus-adapter prometheus-community/prometheus-adapter \
+  --namespace monitoring --create-namespace \
+  -f helm/fluid/prometheus-adapter-values.yaml
+```
+
+Then enable the ServiceMonitor in your values:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  namespace: monitoring
+```
+
+## Secrets management
+
+For production use the External Secrets Operator or Vault Agent Injector instead of chart-managed secrets. Set `secrets.existingSecret` to the name of a pre-existing Kubernetes Secret containing the keys listed in `templates/secrets.yaml`.
+
+## Upgrading
+
+```bash
+helm upgrade fluid ./helm/fluid -f my-values.yaml
+```

--- a/helm/fluid/prometheus-adapter-values.yaml
+++ b/helm/fluid/prometheus-adapter-values.yaml
@@ -1,0 +1,40 @@
+# Values for the prometheus-community/prometheus-adapter Helm chart.
+#
+# This file configures the Prometheus Adapter to expose
+# "http_requests_per_second" as a Kubernetes custom metric so that the Fluid
+# node-api HPA can scale on RPS in addition to CPU.
+#
+# Install the adapter once per cluster:
+#   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+#   helm install prometheus-adapter prometheus-community/prometheus-adapter \
+#     --namespace monitoring --create-namespace \
+#     -f helm/fluid/prometheus-adapter-values.yaml
+#
+# Prerequisites:
+#   - Prometheus Operator or a standalone Prometheus scraping the nginx ingress controller.
+#   - The ingress-nginx controller deployed with --set controller.metrics.enabled=true.
+#   - The ServiceMonitor in templates/servicemonitor.yaml applied with
+#     serviceMonitor.enabled=true in values.yaml.
+
+prometheus:
+  # URL of your Prometheus instance. Adjust for your cluster.
+  url: http://prometheus-operated.monitoring.svc
+  port: 9090
+
+rules:
+  custom:
+    # Derive per-pod RPS for the fluid node-api from nginx ingress metrics.
+    # The metric name must match hpa.values.yaml -> hpa.rpsTargetPerPod metric name.
+    - seriesQuery: 'nginx_ingress_controller_requests{namespace!="",service!=""}'
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          service:
+            resource: service
+      name:
+        matches: "^nginx_ingress_controller_requests$"
+        as: "http_requests_per_second"
+      metricsQuery: |
+        sum(rate(nginx_ingress_controller_requests{<<.LabelMatchers>>,service=~".*node-api.*"}[1m]))
+        by (<<.GroupBy>>)

--- a/helm/fluid/templates/NOTES.txt
+++ b/helm/fluid/templates/NOTES.txt
@@ -1,0 +1,30 @@
+Fluid has been deployed successfully!
+
+Node API endpoint:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+  kubectl port-forward svc/{{ include "fluid.fullname" . }}-node-api 3001:3001
+  then access http://localhost:3001
+{{- end }}
+
+To check the status of all pods:
+  kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+
+To view node-api logs:
+  kubectl logs -l app.kubernetes.io/component=node-api -f
+
+{{- if .Values.hpa.enabled }}
+
+HPA is enabled. The node-api will scale between {{ .Values.hpa.minReplicas }} and {{ .Values.hpa.maxReplicas }} replicas
+based on CPU utilisation (target {{ .Values.hpa.cpuTargetUtilizationPercent }}%) and RPS per pod (target {{ .Values.hpa.rpsTargetPerPod }}).
+
+To watch the autoscaler:
+  kubectl get hpa {{ include "fluid.fullname" . }}-node-api -w
+
+For custom RPS metrics to work, install the Prometheus Adapter with:
+  helm install prometheus-adapter prometheus-community/prometheus-adapter \
+    -f helm/fluid/prometheus-adapter-values.yaml
+{{- end }}

--- a/helm/fluid/templates/_helpers.tpl
+++ b/helm/fluid/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluid.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "fluid.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "fluid.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "fluid.labels" -}}
+helm.sh/chart: {{ include "fluid.chart" . }}
+app.kubernetes.io/name: {{ include "fluid.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels for a given component.
+Usage: {{ include "fluid.selectorLabels" (dict "root" . "component" "node-api") }}
+*/}}
+{{- define "fluid.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fluid.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
+Name of the shared Fluid secrets object.
+*/}}
+{{- define "fluid.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- include "fluid.fullname" . }}-secrets
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the PostgreSQL secret.
+*/}}
+{{- define "fluid.postgresSecretName" -}}
+{{- if .Values.postgres.existingSecret }}
+{{- .Values.postgres.existingSecret }}
+{{- else }}
+{{- include "fluid.fullname" . }}-postgres
+{{- end }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "fluid.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fluid.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/fluid/templates/dashboard-deployment.yaml
+++ b/helm/fluid/templates/dashboard-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fluid.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+spec:
+  replicas: {{ .Values.dashboard.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "fluid.selectorLabels" (dict "root" . "component" "dashboard") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fluid.selectorLabels" (dict "root" . "component" "dashboard") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "fluid.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: dashboard
+          image: "{{ .Values.global.imageRegistry }}{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}"
+          imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.dashboard.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.dashboard.port | quote }}
+            - name: FLUID_SERVER_URL
+              value: "http://{{ include "fluid.fullname" . }}-rust-engine:{{ .Values.rustEngine.service.port }}"
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.secretName" . }}
+                  key: AUTH_SECRET
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.secretName" . }}
+                  key: ADMIN_EMAIL
+            - name: ADMIN_PASSWORD_HASH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.secretName" . }}
+                  key: ADMIN_PASSWORD_HASH
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.dashboard.resources | nindent 12 }}

--- a/helm/fluid/templates/dashboard-service.yaml
+++ b/helm/fluid/templates/dashboard-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluid.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+spec:
+  type: {{ .Values.dashboard.service.type }}
+  selector:
+    {{- include "fluid.selectorLabels" (dict "root" . "component" "dashboard") | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.dashboard.service.port }}
+      targetPort: http

--- a/helm/fluid/templates/hpa.yaml
+++ b/helm/fluid/templates/hpa.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fluid.fullname" . }}-node-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fluid.fullname" . }}-node-api
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    # Scale up when average CPU utilisation across all node-api pods exceeds the threshold.
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.cpuTargetUtilizationPercent }}
+    # Scale up when average RPS per pod exceeds the threshold.
+    # This metric is exposed by the Prometheus Adapter reading
+    # nginx_ingress_controller_requests from the ingress controller.
+    # Install the adapter with:
+    #   helm install prometheus-adapter prometheus-community/prometheus-adapter \
+    #     -f helm/fluid/prometheus-adapter-values.yaml
+    - type: Pods
+      pods:
+        metric:
+          name: http_requests_per_second
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.hpa.rpsTargetPerPod }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        # Allow adding up to 4 pods per minute.
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+        # Or doubling the current replica count per minute — whichever adds more.
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      # Wait 5 minutes of sustained low load before removing pods.
+      # Prevents flapping during brief traffic dips between spikes.
+      stabilizationWindowSeconds: {{ .Values.hpa.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+      selectPolicy: Min
+{{- end }}

--- a/helm/fluid/templates/ingress.yaml
+++ b/helm/fluid/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "fluid.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "fluid.fullname" $ }}-{{ .service }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/fluid/templates/node-api-deployment.yaml
+++ b/helm/fluid/templates/node-api-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fluid.fullname" . }}-node-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node-api
+spec:
+  replicas: {{ .Values.nodeApi.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "fluid.selectorLabels" (dict "root" . "component" "node-api") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fluid.selectorLabels" (dict "root" . "component" "node-api") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "fluid.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: node-api
+          image: "{{ .Values.global.imageRegistry }}{{ .Values.nodeApi.image.repository }}:{{ .Values.nodeApi.image.tag }}"
+          imagePullPolicy: {{ .Values.nodeApi.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.nodeApi.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.nodeApi.port | quote }}
+            - name: STATELESS_MODE
+              value: {{ .Values.nodeApi.statelessMode | quote }}
+            - name: REDIS_URL
+              value: "redis://{{ include "fluid.fullname" . }}-redis:{{ .Values.redis.port }}"
+            - name: DATABASE_URL
+              value: "postgres://{{ .Values.postgres.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "fluid.fullname" . }}-postgres:{{ .Values.postgres.port }}/{{ .Values.postgres.auth.database }}"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.postgresSecretName" . }}
+                  key: postgres-password
+            - name: FLUID_FEE_PAYER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.secretName" . }}
+                  key: FLUID_FEE_PAYER_SECRET
+            - name: DATABASE_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.secretName" . }}
+                  key: DATABASE_ENCRYPTION_KEY
+            - name: FLUID_GRPC_ENGINE_ADDRESS
+              value: "{{ include "fluid.fullname" . }}-rust-engine:50051"
+            {{- with .Values.nodeApi.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.nodeApi.resources | nindent 12 }}

--- a/helm/fluid/templates/node-api-service.yaml
+++ b/helm/fluid/templates/node-api-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluid.fullname" . }}-node-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node-api
+spec:
+  type: {{ .Values.nodeApi.service.type }}
+  selector:
+    {{- include "fluid.selectorLabels" (dict "root" . "component" "node-api") | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.nodeApi.service.port }}
+      targetPort: http

--- a/helm/fluid/templates/postgres-service.yaml
+++ b/helm/fluid/templates/postgres-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluid.fullname" . }}-postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "fluid.selectorLabels" (dict "root" . "component" "postgres") | nindent 4 }}
+  ports:
+    - name: postgres
+      protocol: TCP
+      port: {{ .Values.postgres.port }}
+      targetPort: postgres

--- a/helm/fluid/templates/postgres-statefulset.yaml
+++ b/helm/fluid/templates/postgres-statefulset.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "fluid.fullname" . }}-postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: {{ include "fluid.fullname" . }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fluid.selectorLabels" (dict "root" . "component" "postgres") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fluid.selectorLabels" (dict "root" . "component" "postgres") | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgres.port }}
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.auth.username | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.auth.database | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.postgresSecretName" . }}
+                  key: postgres-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgres.auth.username }}
+                - -d
+                - {{ .Values.postgres.auth.database }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgres.auth.username }}
+                - -d
+                - {{ .Values.postgres.auth.database }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.postgres.storage.storageClass }}
+        storageClassName: {{ .Values.postgres.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage.size }}

--- a/helm/fluid/templates/redis-service.yaml
+++ b/helm/fluid/templates/redis-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluid.fullname" . }}-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "fluid.selectorLabels" (dict "root" . "component" "redis") | nindent 4 }}
+  ports:
+    - name: redis
+      protocol: TCP
+      port: {{ .Values.redis.port }}
+      targetPort: redis

--- a/helm/fluid/templates/redis-statefulset.yaml
+++ b/helm/fluid/templates/redis-statefulset.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "fluid.fullname" . }}-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "fluid.fullname" . }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fluid.selectorLabels" (dict "root" . "component" "redis") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fluid.selectorLabels" (dict "root" . "component" "redis") | nindent 8 }}
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.redis.port }}
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.redis.storage.storageClass }}
+        storageClassName: {{ .Values.redis.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage.size }}

--- a/helm/fluid/templates/rust-engine-deployment.yaml
+++ b/helm/fluid/templates/rust-engine-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fluid.fullname" . }}-rust-engine
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rust-engine
+spec:
+  replicas: {{ .Values.rustEngine.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "fluid.selectorLabels" (dict "root" . "component" "rust-engine") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fluid.selectorLabels" (dict "root" . "component" "rust-engine") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "fluid.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: rust-engine
+          image: "{{ .Values.global.imageRegistry }}{{ .Values.rustEngine.image.repository }}:{{ .Values.rustEngine.image.tag }}"
+          imagePullPolicy: {{ .Values.rustEngine.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.rustEngine.port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: 50051
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.rustEngine.port | quote }}
+            - name: DATABASE_URL
+              value: "postgres://{{ .Values.postgres.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "fluid.fullname" . }}-postgres:{{ .Values.postgres.port }}/{{ .Values.postgres.auth.database }}"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.postgresSecretName" . }}
+                  key: postgres-password
+            - name: FLUID_FEE_PAYER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fluid.secretName" . }}
+                  key: FLUID_FEE_PAYER_SECRET
+            {{- with .Values.rustEngine.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.rustEngine.resources | nindent 12 }}

--- a/helm/fluid/templates/rust-engine-service.yaml
+++ b/helm/fluid/templates/rust-engine-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluid.fullname" . }}-rust-engine
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rust-engine
+spec:
+  type: {{ .Values.rustEngine.service.type }}
+  selector:
+    {{- include "fluid.selectorLabels" (dict "root" . "component" "rust-engine") | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.rustEngine.service.port }}
+      targetPort: http
+    - name: grpc
+      protocol: TCP
+      port: 50051
+      targetPort: grpc

--- a/helm/fluid/templates/secrets.yaml
+++ b/helm/fluid/templates/secrets.yaml
@@ -1,0 +1,29 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fluid.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  FLUID_FEE_PAYER_SECRET: {{ .Values.secrets.fluidFeePayerSecret | quote }}
+  DATABASE_ENCRYPTION_KEY: {{ .Values.secrets.databaseEncryptionKey | quote }}
+  AUTH_SECRET: {{ .Values.secrets.authSecret | quote }}
+  ADMIN_EMAIL: {{ .Values.secrets.adminEmail | quote }}
+  ADMIN_PASSWORD_HASH: {{ .Values.secrets.adminPasswordHash | quote }}
+{{- end }}
+---
+{{- if not .Values.postgres.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fluid.fullname" . }}-postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  postgres-password: {{ .Values.postgres.auth.password | quote }}
+{{- end }}

--- a/helm/fluid/templates/serviceaccount.yaml
+++ b/helm/fluid/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fluid.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/fluid/templates/servicemonitor.yaml
+++ b/helm/fluid/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.serviceMonitor.enabled }}
+# ServiceMonitor for the Prometheus Operator.
+# Instructs Prometheus to scrape metrics from the nginx ingress controller,
+# which exposes nginx_ingress_controller_requests. The Prometheus Adapter then
+# converts that into the http_requests_per_second custom metric consumed by the HPA.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fluid.fullname" . }}-ingress-metrics
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "fluid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node-api
+spec:
+  namespaceSelector:
+    matchNames:
+      - ingress-nginx
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      path: /metrics
+{{- end }}

--- a/helm/fluid/values.yaml
+++ b/helm/fluid/values.yaml
@@ -1,0 +1,220 @@
+# Default values for the Fluid Helm chart.
+# Override these in your own values file or with --set flags.
+
+# -- Global settings ----------------------------------------------------------
+global:
+  # Registry prefix prepended to all image repositories. Leave empty to use
+  # Docker Hub (the default).
+  imageRegistry: ""
+  imagePullSecrets: []
+
+# -- Node API (TypeScript / Express) ------------------------------------------
+nodeApi:
+  image:
+    repository: ghcr.io/stellar-fluid/fluid-node-api
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  replicaCount: 2
+
+  port: 3001
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # Extra environment variables injected into the node-api pods.
+  extraEnv: []
+  # - name: MY_VAR
+  #   value: "my-value"
+
+  # Enable STATELESS_MODE so all replicas share Redis for rate limiting and
+  # API key caching. Always set to "true" when replicaCount > 1.
+  statelessMode: "true"
+
+  service:
+    type: ClusterIP
+    port: 3001
+
+# -- Rust signing engine (Axum) -----------------------------------------------
+rustEngine:
+  image:
+    repository: ghcr.io/stellar-fluid/fluid-rust-engine
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  port: 3000
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
+  extraEnv: []
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+# -- Admin dashboard (Next.js) ------------------------------------------------
+dashboard:
+  image:
+    repository: ghcr.io/stellar-fluid/fluid-dashboard
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  port: 3002
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  service:
+    type: ClusterIP
+    port: 3002
+
+# -- PostgreSQL ---------------------------------------------------------------
+postgres:
+  image:
+    repository: postgres
+    tag: "15-alpine"
+    pullPolicy: IfNotPresent
+
+  port: 5432
+
+  # Name of an existing Kubernetes Secret that contains the PostgreSQL password
+  # under the key "postgres-password". Leave empty to have the chart create a
+  # Secret from the values below.
+  existingSecret: ""
+
+  auth:
+    username: fluid
+    password: ""          # Required when existingSecret is empty
+    database: fluid_db
+
+  storage:
+    size: 10Gi
+    storageClass: ""      # Empty = cluster default StorageClass
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+# -- Redis --------------------------------------------------------------------
+redis:
+  image:
+    repository: redis
+    tag: "7-alpine"
+    pullPolicy: IfNotPresent
+
+  port: 6379
+
+  storage:
+    size: 2Gi
+    storageClass: ""
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+# -- Ingress ------------------------------------------------------------------
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+  #   nginx.ingress.kubernetes.io/proxy-body-size: "4m"
+
+  hosts:
+    - host: api.fluid.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: node-api
+    - host: dashboard.fluid.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: dashboard
+
+  tls: []
+  # - secretName: fluid-tls
+  #   hosts:
+  #     - api.fluid.example.com
+  #     - dashboard.fluid.example.com
+
+# -- Secrets ------------------------------------------------------------------
+# Fluid-specific secrets. All values are base64-encoded by Helm when written to
+# Kubernetes Secrets. Use an external secrets operator for production.
+secrets:
+  # Name of an existing Secret to use for all Fluid credentials.
+  # When set, all values below are ignored.
+  existingSecret: ""
+
+  # Required: Stellar secret key of the fee-payer account.
+  fluidFeePayerSecret: ""
+
+  # Required: 32-byte base64 string for database encryption at rest.
+  databaseEncryptionKey: ""
+
+  # Required: Random string used to sign admin dashboard JWT sessions.
+  authSecret: ""
+
+  # Optional: Admin credentials for the dashboard bootstrap user.
+  adminEmail: "admin@fluid.example.com"
+  adminPasswordHash: ""
+
+# -- ServiceAccount -----------------------------------------------------------
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# -- HorizontalPodAutoscaler (node-api only) ----------------------------------
+hpa:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 20
+
+  # Scale up when average CPU across all node-api pods exceeds this threshold.
+  cpuTargetUtilizationPercent: 70
+
+  # Scale up when average RPS per pod exceeds this value.
+  # Requires the Prometheus Adapter to expose the "http_requests_per_second"
+  # custom metric. See helm/fluid/prometheus-adapter-values.yaml.
+  rpsTargetPerPod: 200
+
+  # Scale-down stabilisation window (seconds). Prevents flapping during
+  # traffic spikes that briefly dip below the threshold.
+  scaleDownStabilizationWindowSeconds: 300
+
+# -- ServiceMonitor (Prometheus Operator) -------------------------------------
+serviceMonitor:
+  # Set to true if the Prometheus Operator CRDs are installed in the cluster.
+  enabled: false
+  namespace: monitoring
+  interval: 15s
+  scrapeTimeout: 10s

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -1,0 +1,40 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Round-robin load balancing across node-api replicas.
+    # Docker Compose --scale resolves "node-api" to all container IPs.
+    upstream fluid_node_api {
+        server node-api:3001;
+        keepalive 32;
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass         http://fluid_node_api;
+            proxy_http_version 1.1;
+            proxy_set_header   Connection        "";
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            # Timeouts suited for fee-bump signing latency
+            proxy_connect_timeout 5s;
+            proxy_send_timeout    30s;
+            proxy_read_timeout    30s;
+        }
+
+        location /health {
+            proxy_pass         http://fluid_node_api/health;
+            proxy_http_version 1.1;
+            proxy_set_header   Connection "";
+            access_log         off;
+        }
+    }
+}

--- a/server/src/middleware/apiKeys.ts
+++ b/server/src/middleware/apiKeys.ts
@@ -18,6 +18,12 @@ import {
   findApiKeyAcrossRegions,
 } from "../services/regionRouter";
 
+// When STATELESS_MODE=true the in-memory API_KEYS map is bypassed so that
+// every instance resolves keys exclusively from Redis → DB. This is required
+// for horizontal scaling: a key registered on one instance must be visible to
+// all other instances without a restart.
+const STATELESS_MODE = process.env.STATELESS_MODE === "true";
+
 export const VALID_CHAINS = ["stellar", "evm", "solana", "cosmos"] as const;
 export type Chain = (typeof VALID_CHAINS)[number];
 
@@ -149,19 +155,23 @@ export async function apiKeyMiddleware(
     // DB error — continue to in-memory fallback
   }
 
-  // 3) In-memory fallback (useful for local dev / tests)
-  const apiKeyConfig = API_KEYS.get(apiKey);
+  // 3) In-memory fallback — disabled in STATELESS_MODE to prevent per-instance
+  //    divergence when running multiple replicas behind a load balancer.
+  if (!STATELESS_MODE) {
+    const apiKeyConfig = API_KEYS.get(apiKey);
 
-  if (!apiKeyConfig) {
-    return next(new AppError("Invalid API key.", 403, "AUTH_FAILED"));
+    if (apiKeyConfig) {
+      // Cache in Redis asynchronously for future hits
+      setCachedApiKey(apiKey, JSON.stringify(apiKeyConfig), 300).catch(() => {});
+
+      res.locals.apiKey = apiKeyConfig;
+      res.locals.db = getDbForRegion(apiKeyConfig.region ?? DEFAULT_REGION);
+      next();
+      return;
+    }
   }
 
-  // Cache in Redis asynchronously for future hits
-  setCachedApiKey(apiKey, JSON.stringify(apiKeyConfig), 300).catch(() => {});
-
-  res.locals.apiKey = apiKeyConfig;
-  res.locals.db = getDbForRegion(apiKeyConfig.region ?? DEFAULT_REGION);
-  next();
+  return next(new AppError("Invalid API key.", 403, "AUTH_FAILED"));
 }
 
 export function listApiKeys(): ApiKeyConfig[] {

--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -3,7 +3,14 @@ import { ApiKeyConfig, maskApiKey } from "./apiKeys";
 import { consumeLeakyBucket } from "../utils/redis";
 import { TenantUsageTracker } from "../services/tenantUsageTracker";
 
-// Fallback in-memory leaky bucket if Redis is unavailable.
+// When STATELESS_MODE=true the in-memory fallback is disabled so that all rate
+// limit state lives exclusively in Redis. This is required for horizontal
+// scaling: multiple Node API replicas sharing a Redis instance will agree on
+// per-key counters, whereas independent in-memory maps would diverge.
+const STATELESS_MODE = process.env.STATELESS_MODE === "true";
+
+// Fallback in-memory leaky bucket used only when Redis is unavailable and
+// STATELESS_MODE is false (single-instance / dev deployments).
 interface LeakyBucketEntry {
   tat: number; // Theoretical Arrival Time
 }
@@ -98,6 +105,16 @@ export async function apiKeyRateLimit(
     }
   } catch (err) {
     // If Redis helper threw, we'll fall back to in-memory below.
+  }
+
+  // In stateless mode Redis is mandatory — refuse to serve rather than allow
+  // divergent per-instance counters to break rate limit guarantees.
+  if (STATELESS_MODE) {
+    res.status(503).json({
+      error: "Rate limit service unavailable. Redis is required in STATELESS_MODE.",
+      code: "SERVICE_UNAVAILABLE",
+    });
+    return;
   }
 
   // Fallback to in-memory windowing if Redis is unavailable


### PR DESCRIPTION
closes #229 - Add docs/adr/ directory with MADR-format ADRs: README, template, ADR-002 (Rust signing engine), ADR-003 (gRPC Node-Rust communication), ADR-004 (Prisma over raw SQL). Link from CONTRIBUTING.md and README.md.

closes #230 - Add STATELESS_MODE env var that disables in-memory API-key and rate-limit fallbacks in apiKeys.ts and rateLimit.ts. All per-instance state is then held exclusively in Redis, making the node-api safe to run as multiple replicas. Add docker-compose.scale.yml (3 replicas + nginx load balancer), infra/nginx.conf, and docs/horizontal-scaling.md. Document STATELESS_MODE in .env.example.

closes #231 - Add helm/fluid/ Helm chart covering node-api, rust-engine, dashboard, PostgreSQL StatefulSet, Redis StatefulSet, Ingress, Secrets, and ServiceAccount. values.yaml provides sensible defaults; secrets are managed via Kubernetes Secrets with support for existingSecret overrides.

closes #232 - Add HPA template (autoscaling/v2) for the node-api with CPU (target 70%) and custom RPS-per-pod (target 200) metrics, min 2 / max 20 replicas, and a 300 s scale-down stabilisation window. Add ServiceMonitor template for Prometheus Operator and prometheus-adapter-values.yaml to expose http_requests_per_second from nginx ingress metrics via the Prometheus Adapter.