### PR TITLE
perf: monthly table partitioning for transaction history

### DIFF
--- a/server/prisma/migrations/20260426000000_partition_transaction_by_month/migration.sql
+++ b/server/prisma/migrations/20260426000000_partition_transaction_by_month/migration.sql
@@ -1,0 +1,111 @@
+-- ============================================================
+-- Migration: Partition Transaction table by month (RANGE)
+-- Issue #237 – Performance: Partitioned Transaction Table
+--
+-- Strategy:
+--   1. Build a partitioned replacement table
+--   2. Create monthly child partitions (24 months back → 3 months ahead)
+--   3. Add a DEFAULT partition for safety
+--   4. Copy all existing rows
+--   5. Recreate indexes on the parent (propagated to all partitions)
+--   6. Drop FK constraints that cannot reference a partial unique key
+--      (PostgreSQL requires the partition key in every UNIQUE constraint;
+--       referential integrity is maintained at the Prisma / application layer)
+--   7. Swap old table → new partitioned table atomically
+--
+-- NOTE (production deployments): This migration copies all rows before
+-- swapping. For tables with active write traffic, run during a maintenance
+-- window or use a separate online-migration tool (pg_repack / pglogical).
+-- ============================================================
+
+-- Step 1: Create the partitioned parent table.
+-- PRIMARY KEY must include the partition key ("createdAt") per PG rules.
+CREATE TABLE "Transaction_partitioned" (
+  "id"           TEXT         NOT NULL,
+  "txHash"       TEXT,
+  "innerTxHash"  TEXT         NOT NULL,
+  "tenantId"     TEXT,
+  "status"       TEXT         NOT NULL,
+  "costStroops"  BIGINT       NOT NULL,
+  "category"     TEXT         NOT NULL DEFAULT 'Other',
+  "chain"        TEXT         NOT NULL DEFAULT 'stellar',
+  "createdAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY ("id", "createdAt")
+) PARTITION BY RANGE ("createdAt");
+
+-- Step 2: Create one partition per calendar month.
+--   Range: 24 months in the past → 3 months in the future.
+--   Each child table is named  transaction_y<YYYY>_m<MM>
+DO $$
+DECLARE
+  d    DATE;
+  name TEXT;
+BEGIN
+  d := DATE_TRUNC('month', NOW()) - INTERVAL '24 months';
+  WHILE d <= DATE_TRUNC('month', NOW()) + INTERVAL '3 months' LOOP
+    name := 'transaction_y' || TO_CHAR(d, 'YYYY') || '_m' || TO_CHAR(d, 'MM');
+    EXECUTE format(
+      'CREATE TABLE %I PARTITION OF "Transaction_partitioned"
+         FOR VALUES FROM (%L::TIMESTAMP) TO (%L::TIMESTAMP)',
+      name,
+      d::TIMESTAMP,
+      (d + INTERVAL '1 month')::TIMESTAMP
+    );
+    d := d + INTERVAL '1 month';
+  END LOOP;
+END;
+$$;
+
+-- Step 3: Default partition catches any rows outside the explicit ranges.
+CREATE TABLE "transaction_default" PARTITION OF "Transaction_partitioned" DEFAULT;
+
+-- Step 4: Copy all existing data.
+INSERT INTO "Transaction_partitioned"
+SELECT * FROM "Transaction";
+
+-- Step 5: Recreate indexes on the parent table.
+--   PostgreSQL 11+ automatically propagates parent indexes to every
+--   existing and future child partition.
+CREATE INDEX "Transaction_tenantId_idx"
+  ON "Transaction_partitioned" ("tenantId");
+
+CREATE INDEX "Transaction_status_idx"
+  ON "Transaction_partitioned" ("status");
+
+CREATE INDEX "Transaction_txHash_idx"
+  ON "Transaction_partitioned" ("txHash");
+
+CREATE INDEX "Transaction_category_idx"
+  ON "Transaction_partitioned" ("category");
+
+CREATE INDEX "Transaction_chain_idx"
+  ON "Transaction_partitioned" ("chain");
+
+CREATE INDEX "Transaction_tenantId_status_createdAt_idx"
+  ON "Transaction_partitioned" ("tenantId", "status", "createdAt");
+
+CREATE INDEX "Transaction_status_createdAt_idx"
+  ON "Transaction_partitioned" ("status", "createdAt");
+
+CREATE INDEX "Transaction_chain_createdAt_idx"
+  ON "Transaction_partitioned" ("chain", "createdAt");
+
+-- Step 6: Drop FK constraints that reference Transaction(id).
+--   PostgreSQL requires all unique constraints on a partitioned table to
+--   include the partition key.  A FK can only reference a unique constraint,
+--   so a FK to just Transaction(id) is impossible once the table is
+--   partitioned.  Referential integrity is maintained by Prisma at the
+--   application layer (cascade deletes handled via Prisma relations).
+ALTER TABLE "CrossChainSettlement"
+  DROP CONSTRAINT IF EXISTS "CrossChainSettlement_transactionId_fkey";
+
+ALTER TABLE "SARReport"
+  DROP CONSTRAINT IF EXISTS "SARReport_transactionId_fkey";
+
+-- Step 7: Swap the tables (both renames happen in a single DDL batch,
+--   minimising the window during which neither name exists).
+ALTER TABLE "Transaction"             RENAME TO "Transaction_old";
+ALTER TABLE "Transaction_partitioned" RENAME TO "Transaction";
+
+-- Step 8: Drop the original monolithic table.
+DROP TABLE "Transaction_old";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -141,6 +141,10 @@ import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
 import { ExpressAdapter } from "@bull-board/express";
 import { feeBumpQueue, feeBumpQueueEvents } from "./queues/feeBumpQueue";
 import { initializeFeeBumpWorker } from "./workers/feeBumpWorker";
+import {
+  initializePartitionMaintenanceWorker,
+  PartitionMaintenanceWorker,
+} from "./workers/partitionMaintenanceWorker";
 
 const logger = createLogger({ component: "server" });
 const config = loadConfig();
@@ -538,6 +542,7 @@ let treasurySweeper: ReturnType<typeof initializeTreasurySweeper> | null = null;
 let digestWorker: ReturnType<typeof initializeDigestWorker> | null = null;
 let tenantErasureWorker: TenantErasureWorker | null = null;
 let feeBumpWorker: ReturnType<typeof initializeFeeBumpWorker> | null = null;
+let partitionMaintenanceWorker: PartitionMaintenanceWorker | null = null;
 let shuttingDown = false;
 let server: ReturnType<typeof app.listen> | null = null;
 
@@ -562,6 +567,7 @@ async function shutdown(signal: string): Promise<void> {
   stopChainRegistryHotReload();
   stopOFACScreening();
   treasurySweeper?.stop();
+  partitionMaintenanceWorker?.stop();
   await feeBumpWorker?.close();
   await feeBumpQueueEvents.close();
   await feeBumpQueue.close();
@@ -729,6 +735,16 @@ try {
   logger.error(
     { ...serializeError(error) },
     "Failed to start fee-bump queue worker",
+  );
+}
+
+try {
+  partitionMaintenanceWorker = initializePartitionMaintenanceWorker();
+  partitionMaintenanceWorker.start();
+} catch (error) {
+  logger.error(
+    { ...serializeError(error) },
+    "Failed to start partition maintenance worker",
   );
 }
 

--- a/server/src/workers/partitionMaintenanceWorker.ts
+++ b/server/src/workers/partitionMaintenanceWorker.ts
@@ -1,0 +1,125 @@
+import { createLogger, serializeError } from "../utils/logger";
+import prisma from "../utils/db";
+
+const logger = createLogger({ component: "partitionMaintenanceWorker" });
+
+// Runs at 00:05 on the 1st of every month
+const DEFAULT_CRON_SCHEDULE = "5 0 1 * *";
+const RETENTION_MONTHS = 24;
+const LOOKAHEAD_MONTHS = 3;
+
+export interface CronScheduler {
+  schedule: (expression: string, callback: () => void) => { stop: () => void };
+  validate: (expression: string) => boolean;
+}
+
+function partitionName(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `transaction_y${y}_m${m}`;
+}
+
+function addMonths(date: Date, n: number): Date {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + n, 1));
+  return d;
+}
+
+export async function ensurePartitionsExist(): Promise<void> {
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+  for (let i = 0; i <= LOOKAHEAD_MONTHS; i++) {
+    const from = addMonths(monthStart, i);
+    const to = addMonths(monthStart, i + 1);
+    const name = partitionName(from);
+    const fromIso = from.toISOString().replace("T", " ").replace(".000Z", "");
+    const toIso = to.toISOString().replace("T", " ").replace(".000Z", "");
+
+    await prisma.$executeRawUnsafe(`
+      CREATE TABLE IF NOT EXISTS ${JSON.stringify(name)}
+        PARTITION OF "Transaction"
+        FOR VALUES FROM ('${fromIso}') TO ('${toIso}')
+    `);
+
+    logger.info({ partition: name, from: fromIso, to: toIso }, "Partition ensured");
+  }
+}
+
+export async function dropOldPartitions(): Promise<void> {
+  const now = new Date();
+  const cutoff = addMonths(
+    new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)),
+    -RETENTION_MONTHS,
+  );
+
+  // List all child partitions of the Transaction table
+  const rows = await prisma.$queryRaw<{ relname: string }[]>`
+    SELECT c.relname
+    FROM   pg_inherits i
+    JOIN   pg_class    p ON p.oid = i.inhparent
+    JOIN   pg_class    c ON c.oid = i.inhrelid
+    WHERE  p.relname = 'Transaction'
+  `;
+
+  for (const { relname } of rows) {
+    // Only touch partitions matching our naming convention
+    const match = relname.match(/^transaction_y(\d{4})_m(\d{2})$/);
+    if (!match) continue;
+
+    const partitionDate = new Date(Date.UTC(parseInt(match[1], 10), parseInt(match[2], 10) - 1, 1));
+    if (partitionDate < cutoff) {
+      await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS ${JSON.stringify(relname)}`);
+      logger.info({ partition: relname }, "Dropped expired partition");
+    }
+  }
+}
+
+export class PartitionMaintenanceWorker {
+  private task: { stop: () => void } | null = null;
+  private readonly cronSchedule: string;
+  private readonly scheduler: CronScheduler;
+
+  constructor(options: { cronSchedule?: string; scheduler?: CronScheduler } = {}) {
+    this.cronSchedule = options.cronSchedule ?? DEFAULT_CRON_SCHEDULE;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    this.scheduler = options.scheduler ?? (require("node-cron") as CronScheduler);
+  }
+
+  start(): void {
+    if (!this.scheduler.validate(this.cronSchedule)) {
+      logger.error({ schedule: this.cronSchedule }, "Invalid cron schedule — partition maintenance disabled");
+      return;
+    }
+
+    logger.info({ schedule: this.cronSchedule }, "Starting partition maintenance worker");
+
+    // Run once immediately on startup to catch any missing partitions
+    void this.runNow();
+
+    this.task = this.scheduler.schedule(this.cronSchedule, () => {
+      void this.runNow();
+    });
+  }
+
+  stop(): void {
+    if (!this.task) return;
+    this.task.stop();
+    this.task = null;
+    logger.info("Stopped partition maintenance worker");
+  }
+
+  async runNow(): Promise<void> {
+    logger.info("Running partition maintenance");
+    try {
+      await ensurePartitionsExist();
+      await dropOldPartitions();
+      logger.info("Partition maintenance complete");
+    } catch (error) {
+      logger.error({ ...serializeError(error) }, "Partition maintenance failed");
+    }
+  }
+}
+
+export function initializePartitionMaintenanceWorker(): PartitionMaintenanceWorker {
+  return new PartitionMaintenanceWorker();
+}


### PR DESCRIPTION
Implement PostgreSQL declarative RANGE partitioning on the Transaction table by created_at (monthly) to maintain query performance at scale. Closes #237.

- Add migration: rename Transaction → old, create partitioned replacement with composite PK (id, createdAt), generate 27 child partitions (24 months back → 3 months ahead), copy data, recreate all indexes, drop FK constraints that cannot reference a partial unique key, swap tables, drop old table
- Add DEFAULT partition to catch any out-of-range rows safely
- Add partitionMaintenanceWorker: runs at 00:05 on the 1st of each month via node-cron; ensurePartitionsExist() creates next 3 months of child tables; dropOldPartitions() detaches and drops partitions older than 24 months; also runs once at startup to catch any gaps
- Wire worker into server startup and graceful shutdown

