### PR TITLE
feat: sponsorship-quotas

### DIFF
--- a/docs/sponsorship-quotas.md
+++ b/docs/sponsorship-quotas.md
@@ -1,0 +1,39 @@
+# Sponsorship Quotas
+
+Fluid enforces per-tenant sponsorship quotas to ensure predictable fee sponsorship and avoid runaway XLM spend.
+
+## What is enforced
+
+- `dailyQuotaStroops`: the maximum amount of sponsored fee spend allowed per tenant per UTC day.
+- `txLimit`: the maximum number of sponsored transactions allowed per tenant per UTC day.
+
+## How quota enforcement works
+
+- The server tracks each sponsored Stellar fee bump in `sponsoredTransaction`.
+- Quota checks compare the tenant's current daily spend and transaction count against the configured daily quota and transaction limit.
+- Quota enforcement applies to both:
+  - `POST /fee-bump`
+  - `POST /fee-bump/batch`
+
+## Batch request behavior
+
+- `POST /fee-bump/batch` performs a cumulative quota check for all requested XDRs.
+- The server computes the total projected fee spend and total transaction count for the batch before any sponsorship is created.
+- If the batch would exceed either the daily spend quota or the daily transaction limit, the server rejects the request with `QUOTA_EXCEEDED`.
+
+## Error response
+
+When a quota is exceeded, Fluid returns a 403 error with a machine-readable code:
+
+```json
+{
+  "error": "Tier limit exceeded. Spend 900000/1000000 stroops and transactions 10/10 today.",
+  "code": "QUOTA_EXCEEDED"
+}
+```
+
+## Developer notes
+
+- Quotas are enforced using UTC calendar days.
+- Per-tenant quota values are sourced from tenant API key configuration and can be updated by billing/top-up workflows.
+- `sponsoredTransaction` history is the trusted source of truth for daily quota reconciliation.

--- a/server/src/handlers/feeBump.batchQuota.test.ts
+++ b/server/src/handlers/feeBump.batchQuota.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import StellarSdk from "@stellar/stellar-sdk";
+import { feeBumpBatchHandler } from "./feeBump";
+
+const mockEnforceKyc = vi.fn().mockResolvedValue(undefined);
+const mockCheckTenantDailyQuota = vi.fn().mockResolvedValue({
+  allowed: true,
+  currentSpendStroops: 0,
+  projectedSpendStroops: 200,
+  dailyQuotaStroops: 1_000_000,
+  currentTxCount: 0,
+  projectedTxCount: 2,
+  txLimit: 10,
+});
+const mockBuildSponsoredTx = vi.fn().mockResolvedValue({
+  tx: "fake-fee-bump-xdr",
+  status: "ready",
+  feePayer: "GFAKEKEY1234567890",
+});
+
+vi.mock("../services/kycService", () => ({
+  enforceKycForFeeSponsorship: mockEnforceKyc,
+}));
+vi.mock("../services/quota", () => ({
+  checkTenantDailyQuota: mockCheckTenantDailyQuota,
+}));
+vi.mock("../sponsors/stellar", () => ({
+  StellarFeeSponsor: vi.fn().mockImplementation(() => ({
+    buildSponsoredTx: mockBuildSponsoredTx,
+  })),
+}));
+
+function buildSignedXdr(networkPassphrase: string): string {
+  const source = StellarSdk.Keypair.random();
+  const tx = new StellarSdk.TransactionBuilder(
+    new StellarSdk.Account(source.publicKey(), "1"),
+    {
+      fee: 100,
+      networkPassphrase,
+    },
+  )
+    .addOperation(
+      StellarSdk.Operation.payment({
+        destination: StellarSdk.Keypair.random().publicKey(),
+        asset: StellarSdk.Asset.native(),
+        amount: "1.0",
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(source);
+  return tx.toXDR();
+}
+
+describe("feeBumpBatchHandler quota enforcement", () => {
+  beforeEach(() => {
+    mockEnforceKyc.mockClear();
+    mockCheckTenantDailyQuota.mockClear();
+    mockBuildSponsoredTx.mockClear();
+  });
+
+  it("checks batch quota using the total number of transactions", async () => {
+    const xdr1 = buildSignedXdr(StellarSdk.Networks.TESTNET);
+    const xdr2 = buildSignedXdr(StellarSdk.Networks.TESTNET);
+
+    const req = {
+      body: {
+        xdrs: [xdr1, xdr2],
+        submit: false,
+      },
+      headers: {},
+      method: "POST",
+      url: "/fee-bump/batch",
+      header: () => undefined,
+    } as any;
+
+    const res = {
+      locals: {
+        apiKey: {
+          key: "test-key",
+          tenantId: "test-tenant",
+          name: "Test Tenant",
+          region: "US",
+          tier: "free",
+          tierName: "Free",
+          txLimit: 10,
+          rateLimit: 5,
+          priceMonthly: 0,
+          dailyQuotaStroops: 1_000_000,
+        },
+      },
+      json: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+    } as any;
+
+    const next = vi.fn();
+    const config = {
+      networkPassphrase: StellarSdk.Networks.TESTNET,
+      baseFee: 100,
+      feeMultiplier: 1.0,
+      supportedAssets: [],
+    } as any;
+
+    await feeBumpBatchHandler(req, res, next, config);
+
+    expect(mockCheckTenantDailyQuota).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "test-tenant" }),
+      expect.any(Number),
+      2,
+    );
+    expect(mockBuildSponsoredTx).toHaveBeenCalledTimes(2);
+    expect(res.json).toHaveBeenCalledWith([
+      expect.objectContaining({ tx: "fake-fee-bump-xdr", status: "ready" }),
+      expect.objectContaining({ tx: "fake-fee-bump-xdr", status: "ready" }),
+    ]);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects a batch when the total transaction count exceeds quota", async () => {
+    mockCheckTenantDailyQuota.mockResolvedValueOnce({
+      allowed: false,
+      currentSpendStroops: 900_000,
+      projectedSpendStroops: 900_000,
+      dailyQuotaStroops: 900_000,
+      currentTxCount: 9,
+      projectedTxCount: 11,
+      txLimit: 10,
+    });
+
+    const xdr1 = buildSignedXdr(StellarSdk.Networks.TESTNET);
+    const xdr2 = buildSignedXdr(StellarSdk.Networks.TESTNET);
+
+    const req = {
+      body: { xdrs: [xdr1, xdr2], submit: false },
+      headers: {},
+      method: "POST",
+      url: "/fee-bump/batch",
+      header: () => undefined,
+    } as any;
+
+    const res = {
+      locals: {
+        apiKey: {
+          key: "test-key",
+          tenantId: "test-tenant",
+          name: "Test Tenant",
+          region: "US",
+          tier: "free",
+          tierName: "Free",
+          txLimit: 10,
+          rateLimit: 5,
+          priceMonthly: 0,
+          dailyQuotaStroops: 900_000,
+        },
+      },
+      json: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+    } as any;
+
+    const next = vi.fn();
+    const config = {
+      networkPassphrase: StellarSdk.Networks.TESTNET,
+      baseFee: 100,
+      feeMultiplier: 1.0,
+      supportedAssets: [],
+    } as any;
+
+    await feeBumpBatchHandler(req, res, next, config);
+
+    expect(mockCheckTenantDailyQuota).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "test-tenant" }),
+      expect.any(Number),
+      2,
+    );
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+    const error = next.mock.calls[0][0];
+    expect(error).toBeInstanceOf(Error);
+    expect(error.code).toBe("QUOTA_EXCEEDED");
+  });
+});

--- a/server/src/handlers/feeBump.ts
+++ b/server/src/handlers/feeBump.ts
@@ -88,7 +88,10 @@ function parseInnerTransaction(xdr: string, config: Config): Transaction {
     throw new AppError(`Invalid XDR: ${error.message}`, 400, "INVALID_XDR");
   }
 
-  if (!innerTransaction.signatures || innerTransaction.signatures.length === 0) {
+  if (
+    !innerTransaction.signatures ||
+    innerTransaction.signatures.length === 0
+  ) {
     throw new AppError(
       "Inner transaction must be signed before fee-bumping",
       400,
@@ -353,7 +356,9 @@ export async function feeBumpHandler(
 
     const apiKeyConfig = res.locals.apiKey as ApiKeyConfig | undefined;
     if (!apiKeyConfig) {
-      res.status(500).json({ error: "Missing tenant context for fee sponsorship" });
+      res
+        .status(500)
+        .json({ error: "Missing tenant context for fee sponsorship" });
       return;
     }
 
@@ -422,9 +427,11 @@ export async function feeBumpHandler(
       }
 
       const isSoroban = innerTransaction.operations.some((op: any) =>
-        ["invokeHostFunction", "extendFootprintTtl", "restoreFootprint"].includes(
-          op.type,
-        ),
+        [
+          "invokeHostFunction",
+          "extendFootprintTtl",
+          "restoreFootprint",
+        ].includes(op.type),
       );
 
       if (isSoroban) {
@@ -505,7 +512,10 @@ export async function feeBumpHandler(
       }
 
       const prepared = prepareFeeBump(effectiveXdr, config);
-      const quotaCheck = await checkTenantDailyQuota(tenant, prepared.feeAmount);
+      const quotaCheck = await checkTenantDailyQuota(
+        tenant,
+        prepared.feeAmount,
+      );
       if (!quotaCheck.allowed) {
         return next(
           new AppError(
@@ -621,7 +631,9 @@ export async function feeBumpBatchHandler(
     const body: FeeBumpBatchRequest = parsedBody.data;
     const apiKeyConfig = res.locals.apiKey as ApiKeyConfig | undefined;
     if (!apiKeyConfig) {
-      res.status(500).json({ error: "Missing tenant context for fee sponsorship" });
+      res
+        .status(500)
+        .json({ error: "Missing tenant context for fee sponsorship" });
       return;
     }
 
@@ -640,17 +652,60 @@ export async function feeBumpBatchHandler(
       ),
     );
 
-    const results = await Promise.all(
-      body.xdrs.map((xdr) =>
-        stellarSponsor.buildSponsoredTx({
-          config,
-          feePayerAccount,
-          submit: body.submit ?? false,
-          tenant,
-          xdr,
-        }),
-      ),
+    const preparedFeeBumps = body.xdrs.map((xdr) =>
+      prepareFeeBump(xdr, config),
     );
+    const totalFeeStroops = preparedFeeBumps.reduce(
+      (sum, prepared) => sum + prepared.feeAmount,
+      0,
+    );
+
+    const quotaCheck = await checkTenantDailyQuota(
+      tenant,
+      totalFeeStroops,
+      body.xdrs.length,
+    );
+
+    if (!quotaCheck.allowed) {
+      throw new AppError(
+        `Tier limit exceeded. Spend ${quotaCheck.currentSpendStroops}/${quotaCheck.dailyQuotaStroops} stroops and transactions ${quotaCheck.currentTxCount}/${quotaCheck.txLimit} today.`,
+        403,
+        "QUOTA_EXCEEDED",
+      );
+    }
+
+    if (body.token) {
+      const supportedAssets = config.supportedAssets ?? [];
+      const isWhitelisted = supportedAssets.some((asset) => {
+        const assetId = asset.issuer
+          ? `${asset.code}:${asset.issuer}`
+          : asset.code;
+        return body.token === assetId;
+      });
+
+      if (!isWhitelisted) {
+        throw new AppError(
+          `Whitelisting failed: Asset "${body.token}" is not accepted for fee sponsorship.`,
+          400,
+          "UNSUPPORTED_ASSET",
+        );
+      }
+    }
+
+    const results: Array<
+      Awaited<ReturnType<typeof stellarSponsor.buildSponsoredTx>>
+    > = [];
+    for (const xdr of body.xdrs) {
+      const result = await stellarSponsor.buildSponsoredTx({
+        config,
+        feePayerAccount,
+        submit: body.submit ?? false,
+        tenant,
+        xdr,
+        token: body.token,
+      });
+      results.push(result);
+    }
 
     res.json(results);
   } catch (error: any) {

--- a/server/src/services/quota.test.ts
+++ b/server/src/services/quota.test.ts
@@ -67,4 +67,16 @@ describe("checkTenantDailyQuota", () => {
     expect(result.projectedTxCount).toBe(121);
     expect(result.projectedSpendStroops).toBe(205_000);
   });
+
+  it("accounts for multiple transactions in a batch quota check", async () => {
+    mockedSpend.mockResolvedValue(800_000);
+    mockedCount.mockResolvedValue(8);
+
+    const result = await checkTenantDailyQuota(buildTenant(), 50_000, 3);
+
+    expect(result.allowed).toBe(false);
+    expect(result.currentTxCount).toBe(8);
+    expect(result.projectedTxCount).toBe(11);
+    expect(result.txLimit).toBe(10);
+  });
 });

--- a/server/src/services/quota.ts
+++ b/server/src/services/quota.ts
@@ -17,14 +17,15 @@ export interface QuotaCheckResult {
 export async function checkTenantDailyQuota(
   tenant: Tenant,
   feeStroops: number,
-  now: Date = new Date()
+  transactionCount = 1,
+  now: Date = new Date(),
 ): Promise<QuotaCheckResult> {
   const [currentSpendStroops, currentTxCount] = await Promise.all([
     getTenantDailySpendStroops(tenant.id, now),
     getTenantDailyTransactionCount(tenant.id, now),
   ]);
   const projectedSpendStroops = currentSpendStroops + feeStroops;
-  const projectedTxCount = currentTxCount + 1;
+  const projectedTxCount = currentTxCount + transactionCount;
 
   return {
     allowed:


### PR DESCRIPTION
Close #519 


# PR Document: `feat: sponsorship-quotas`

## Summary

This PR adds robust sponsorship quota enforcement for the server package, including batch quota handling and documentation. It ensures Fluid checks both daily XLM spend and transaction count before processing supported `POST /fee-bump` and `POST /fee-bump/batch` requests.

## What changed

- quota.ts
  - Extended `checkTenantDailyQuota` to support batch transaction count.
  - Computes projected spend and projected TX count before authorization.

- feeBump.ts
  - Added cumulative quota evaluation for `feeBumpBatchHandler`.
  - Prepares and totals batch fee estimates before any sponsorship action.
  - Rejects batch requests that exceed either:
    - `dailyQuotaStroops`
    - `txLimit`
  - Preserves KYC and token whitelist validation.
  - Builds sponsored transactions only after the batch quota check passes.

- quota.test.ts
  - Added coverage for batch quota transaction counting.
  - Verified behavior when transaction count alone would exceed tier limits.

- feeBump.batchQuota.test.ts
  - Added regression coverage for `POST /fee-bump/batch`.
  - Validates:
    - batch quota call includes total batch size
    - success path with 2 XDRs
    - rejection when total transaction count exceeds quota

- sponsorship-quotas.md
  - New documentation describing quota semantics, batch behavior, and expected error responses.

## Files changed

- quota.ts
- feeBump.ts
- quota.test.ts
- feeBump.batchQuota.test.ts
- sponsorship-quotas.md

## Verification

### Tests
Run from server:

```bash
cd server
npm test -- --run src/services/quota.test.ts src/handlers/feeBump.batchQuota.test.ts
```

### Expected behavior
- A `POST /fee-bump/batch` request now validates total batch spend and total batch transaction count before sponsorship.
- If the batch would exceed quota, the server returns `403` with `code: "QUOTA_EXCEEDED"`.
- Single fee-bump requests still use the existing per-request quota check path..