### PR TITLE
Add fuzzing, parity checks, audit log filters, and SSE log streaming

### DIFF
--- a/admin-dashboard/app/admin/audit-logs/page.tsx
+++ b/admin-dashboard/app/admin/audit-logs/page.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { getAuditLogsData, type AuditLogEntry, type AuditLogPageData } from "@/lib/audit-logs-data";
+import { RotateCcw } from "lucide-react";
+import {
+  getAuditLogsData,
+  type AuditLogEntry,
+  type AuditLogFilters,
+  type AuditLogPageData,
+  type AuditLogTimePeriod,
+} from "@/lib/audit-logs-data";
 import { buildAuditTrailSnapshot } from "@/lib/audit-trail-snapshots";
 
 function AiSummaryTooltip({ summary }: { summary: string }) {
@@ -57,6 +64,12 @@ function SnapshotPopover({ entry, baseline }: { entry: AuditLogEntry; baseline: 
 
 function AuditLogRow({ entry, baseline }: { entry: AuditLogEntry; baseline: AuditLogEntry | null }) {
   const time = new Date(entry.createdAt).toLocaleString();
+  const riskTone =
+    entry.riskScore >= 80
+      ? "bg-rose-50 text-rose-700 ring-rose-200"
+      : entry.riskScore >= 50
+        ? "bg-amber-50 text-amber-700 ring-amber-200"
+        : "bg-emerald-50 text-emerald-700 ring-emerald-200";
 
   return (
     <tr className="border-b border-slate-100 hover:bg-slate-50/60 transition">
@@ -66,7 +79,14 @@ function AuditLogRow({ entry, baseline }: { entry: AuditLogEntry; baseline: Audi
           {entry.action}
         </span>
       </td>
+      <td className="px-4 py-3 text-sm text-slate-600">{entry.actionCategory}</td>
       <td className="px-4 py-3 text-sm text-slate-700">{entry.actor}</td>
+      <td className="px-4 py-3 font-mono text-sm text-slate-500">{entry.ipAddress ?? "—"}</td>
+      <td className="px-4 py-3 text-sm">
+        <span className={`inline-flex min-w-12 justify-center rounded-md px-2 py-0.5 text-xs font-semibold ring-1 ${riskTone}`}>
+          {entry.riskScore}
+        </span>
+      </td>
       <td className="max-w-40 truncate px-4 py-3 font-mono text-sm text-slate-500">
         {entry.target ?? "—"}
       </td>
@@ -87,20 +107,37 @@ function AuditLogRow({ entry, baseline }: { entry: AuditLogEntry; baseline: Audi
   );
 }
 
+const emptyFilters: AuditLogFilters = {
+  actionCategory: "",
+  ipAddress: "",
+  maxRiskScore: undefined,
+  minRiskScore: undefined,
+  timePeriod: "all",
+};
+
 export default function AdminAuditLogsPage() {
   const { data: session } = useSession();
   const [data, setData] = useState<AuditLogPageData | null>(null);
   const [loading, setLoading] = useState(true);
   const [offset, setOffset] = useState(0);
+  const [filters, setFilters] = useState<AuditLogFilters>(emptyFilters);
   const limit = 50;
 
   useEffect(() => {
     setLoading(true);
-    getAuditLogsData(limit, offset).then(setData).finally(() => setLoading(false));
-  }, [offset]);
+    getAuditLogsData(limit, offset, filters).then(setData).finally(() => setLoading(false));
+  }, [offset, filters]);
 
   const hasPrev = offset > 0;
   const hasNext = data ? offset + limit < data.total : false;
+  const updateFilter = (updates: AuditLogFilters) => {
+    setOffset(0);
+    setFilters((current) => ({ ...current, ...updates }));
+  };
+  const resetFilters = () => {
+    setOffset(0);
+    setFilters(emptyFilters);
+  };
 
   return (
     <main className="min-h-screen bg-slate-100">
@@ -133,6 +170,93 @@ export default function AdminAuditLogsPage() {
       </div>
 
       <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-4 border border-slate-200 bg-white px-4 py-4 shadow-sm">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[1.1fr_1fr_0.9fr_0.75fr_0.75fr_auto] xl:items-end">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              IP
+              <input
+                type="search"
+                value={filters.ipAddress ?? ""}
+                onChange={(event) => updateFilter({ ipAddress: event.target.value })}
+                placeholder="203.0.113"
+                className="mt-1 h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm normal-case tracking-normal text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              />
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Category
+              <select
+                value={filters.actionCategory ?? ""}
+                onChange={(event) => updateFilter({ actionCategory: event.target.value })}
+                className="mt-1 h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm normal-case tracking-normal text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              >
+                <option value="">All categories</option>
+                {(data?.actionCategories ?? []).map((category) => (
+                  <option key={category} value={category}>
+                    {category}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Period
+              <select
+                value={filters.timePeriod ?? "all"}
+                onChange={(event) =>
+                  updateFilter({ timePeriod: event.target.value as AuditLogTimePeriod })
+                }
+                className="mt-1 h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm normal-case tracking-normal text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              >
+                <option value="all">All time</option>
+                <option value="24h">Last 24h</option>
+                <option value="7d">Last 7d</option>
+                <option value="30d">Last 30d</option>
+              </select>
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Min Risk
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={filters.minRiskScore ?? ""}
+                onChange={(event) =>
+                  updateFilter({
+                    minRiskScore:
+                      event.target.value === "" ? undefined : Number(event.target.value),
+                  })
+                }
+                className="mt-1 h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm normal-case tracking-normal text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              />
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Max Risk
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={filters.maxRiskScore ?? ""}
+                onChange={(event) =>
+                  updateFilter({
+                    maxRiskScore:
+                      event.target.value === "" ? undefined : Number(event.target.value),
+                  })
+                }
+                className="mt-1 h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm normal-case tracking-normal text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              />
+            </label>
+            <div className="flex">
+              <button
+                type="button"
+                aria-label="Reset audit log filters"
+                onClick={resetFilters}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-slate-300 bg-white text-slate-700 shadow-sm hover:bg-slate-50"
+              >
+                <RotateCcw className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+
         {loading ? (
           <div className="animate-pulse space-y-4">
             <div className="h-64 bg-slate-200 rounded-xl" />
@@ -146,7 +270,10 @@ export default function AdminAuditLogsPage() {
                 <tr>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Time</th>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Action</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Category</th>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Actor</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">IP</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Risk</th>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Target</th>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">AI Summary</th>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Snapshot</th>
@@ -155,8 +282,8 @@ export default function AdminAuditLogsPage() {
               <tbody>
                 {data.items.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className="px-4 py-12 text-center text-sm text-slate-400">
-                      No audit logs yet
+                    <td colSpan={9} className="px-4 py-12 text-center text-sm text-slate-400">
+                      No audit logs match the current filters
                     </td>
                   </tr>
                 ) : (

--- a/admin-dashboard/app/admin/webhooks/logs/page.tsx
+++ b/admin-dashboard/app/admin/webhooks/logs/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
+import { ServerLogStreamViewer } from "@/components/dashboard/ServerLogStreamViewer";
 import { WebhookDeliveryLogTable } from "@/components/dashboard/WebhookDeliveryLog";
 import type { WebhookDeliveryPageData, WebhookDeliveryQuery } from "@/components/dashboard/types";
 import { getWebhookDeliveryLogsData } from "@/lib/webhook-delivery-logs-data";
@@ -121,7 +122,8 @@ export default function AdminWebhookLogsPage() {
         </div>
       </div>
 
-      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+        <ServerLogStreamViewer />
         <WebhookDeliveryLogTable
           data={data}
           onPageChange={handlePageChange}

--- a/admin-dashboard/app/api/admin/logs/sse/route.ts
+++ b/admin-dashboard/app/api/admin/logs/sse/route.ts
@@ -1,0 +1,90 @@
+import { auth } from "@/auth";
+import { fluidAdminToken, fluidServerUrl } from "@/lib/server-env";
+import { createServerLogEvent, formatSseEvent } from "@/lib/server-log-stream";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const encoder = new TextEncoder();
+
+function sseHeaders() {
+  return {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no",
+  };
+}
+
+async function proxyUpstreamLogStream(): Promise<Response | null> {
+  const upstreamUrl =
+    process.env.FLUID_SERVER_LOG_SSE_URL?.trim() || `${fluidServerUrl}/admin/logs/sse`;
+
+  try {
+    const upstream = await fetch(upstreamUrl, {
+      headers: {
+        Accept: "text/event-stream",
+        "Cache-Control": "no-cache",
+        ...(fluidAdminToken ? { "x-admin-token": fluidAdminToken } : {}),
+      },
+      // @ts-expect-error Node fetch accepts streaming request options.
+      duplex: "half",
+    });
+
+    if (!upstream.ok || !upstream.body) {
+      return null;
+    }
+
+    return new Response(upstream.body, { headers: sseHeaders() });
+  } catch {
+    return null;
+  }
+}
+
+function localLogStream(): Response {
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const send = (event: string, data: unknown, id?: string) => {
+        controller.enqueue(encoder.encode(formatSseEvent(event, data, id)));
+      };
+
+      const connected = createServerLogEvent({
+        id: "dashboard-log-stream-connected",
+        level: "info",
+        message: "Dashboard log stream connected",
+        service: "admin-dashboard",
+      });
+      const upstreamUnavailable = createServerLogEvent({
+        level: "warn",
+        message: "Fluid server log stream is unavailable; waiting for upstream logs",
+        service: "admin-dashboard",
+      });
+
+      send("connected", { ok: true, timestamp: connected.timestamp }, connected.id);
+      send("log", connected, connected.id);
+      send("log", upstreamUnavailable, upstreamUnavailable.id);
+
+      heartbeat = setInterval(() => {
+        send("heartbeat", { timestamp: new Date().toISOString() });
+      }, 15_000);
+    },
+    cancel() {
+      if (heartbeat) {
+        clearInterval(heartbeat);
+      }
+    },
+  });
+
+  return new Response(stream, { headers: sseHeaders() });
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return (await proxyUpstreamLogStream()) ?? localLogStream();
+}

--- a/admin-dashboard/components/dashboard/ServerLogStreamViewer.tsx
+++ b/admin-dashboard/components/dashboard/ServerLogStreamViewer.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Pause, Play, Radio, Trash2 } from "lucide-react";
+import { parseServerLogEvent, type ServerLogEvent, type ServerLogLevel } from "@/lib/server-log-stream";
+
+const MAX_LOG_ROWS = 200;
+
+const levelClassName: Record<ServerLogLevel, string> = {
+  debug: "bg-slate-100 text-slate-700 ring-slate-200",
+  error: "bg-rose-50 text-rose-700 ring-rose-200",
+  info: "bg-sky-50 text-sky-700 ring-sky-200",
+  warn: "bg-amber-50 text-amber-700 ring-amber-200",
+};
+
+function formatTimestamp(timestamp: string) {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function ServerLogStreamViewer() {
+  const [connected, setConnected] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [logs, setLogs] = useState<ServerLogEvent[]>([]);
+
+  useEffect(() => {
+    if (paused) {
+      setConnected(false);
+      return;
+    }
+
+    const eventSource = new EventSource("/api/admin/logs/sse");
+
+    eventSource.addEventListener("connected", () => setConnected(true));
+    eventSource.addEventListener("heartbeat", () => setConnected(true));
+    eventSource.addEventListener("log", (event) => {
+      const parsed = parseServerLogEvent(event.data);
+      if (!parsed) {
+        return;
+      }
+
+      setLogs((current) => {
+        if (current.some((entry) => entry.id === parsed.id)) {
+          return current;
+        }
+
+        return [parsed, ...current].slice(0, MAX_LOG_ROWS);
+      });
+    });
+
+    eventSource.onerror = () => setConnected(false);
+
+    return () => eventSource.close();
+  }, [paused]);
+
+  const errorCount = useMemo(
+    () => logs.filter((entry) => entry.level === "error").length,
+    [logs],
+  );
+
+  return (
+    <section className="overflow-hidden border border-slate-200 bg-white shadow-sm">
+      <div className="flex flex-col gap-3 border-b border-slate-200 px-5 py-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Server Logs</h2>
+          <div className="mt-1 flex flex-wrap items-center gap-3 text-sm text-slate-500">
+            <span className="inline-flex items-center gap-2">
+              <span className={`h-2.5 w-2.5 rounded-full ${connected ? "bg-emerald-500" : "bg-rose-400"}`} />
+              {connected ? "Live" : "Disconnected"}
+            </span>
+            <span>{logs.length} buffered</span>
+            <span>{errorCount} errors</span>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            aria-label={paused ? "Resume server log stream" : "Pause server log stream"}
+            onClick={() => setPaused((current) => !current)}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-slate-300 bg-white text-slate-700 shadow-sm hover:bg-slate-50"
+          >
+            {paused ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+          </button>
+          <button
+            type="button"
+            aria-label="Clear server logs"
+            onClick={() => setLogs([])}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-slate-300 bg-white text-slate-700 shadow-sm hover:bg-slate-50"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="max-h-96 overflow-auto bg-slate-950">
+        {logs.length === 0 ? (
+          <div className="flex min-h-40 items-center justify-center gap-2 px-5 py-8 text-sm text-slate-400">
+            <Radio className="h-4 w-4" />
+            Waiting for server log events
+          </div>
+        ) : (
+          <ul className="divide-y divide-slate-800">
+            {logs.map((entry) => (
+              <li key={entry.id} className="grid gap-3 px-5 py-3 text-sm md:grid-cols-[5.5rem_5rem_8rem_1fr]">
+                <span className="font-mono text-slate-400">{formatTimestamp(entry.timestamp)}</span>
+                <span>
+                  <span className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold uppercase ring-1 ${levelClassName[entry.level]}`}>
+                    {entry.level}
+                  </span>
+                </span>
+                <span className="truncate font-mono text-slate-400">{entry.service}</span>
+                <span className="min-w-0 break-words text-slate-100">{entry.message}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/admin-dashboard/lib/audit-logs-data.test.ts
+++ b/admin-dashboard/lib/audit-logs-data.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  extractActionCategories,
+  filterAuditLogs,
+  getAuditLogsData,
+  normalizeAuditLogFilters,
+  type AuditLogEntry,
+} from "./audit-logs-data.ts";
+
+const entries: AuditLogEntry[] = [
+  {
+    actionCategory: "Auth",
+    actor: "admin@fluid.dev",
+    action: "auth.login_failed",
+    aiSummary: "Failed login",
+    createdAt: "2026-05-31T10:00:00.000Z",
+    id: "one",
+    ipAddress: "203.0.113.10",
+    metadata: null,
+    riskScore: 92,
+    target: "admin@fluid.dev",
+  },
+  {
+    actionCategory: "API Key",
+    actor: "system",
+    action: "apikey.revoke",
+    aiSummary: "Revoked key",
+    createdAt: "2026-05-29T10:00:00.000Z",
+    id: "two",
+    ipAddress: "198.51.100.22",
+    metadata: null,
+    riskScore: 64,
+    target: "key_1",
+  },
+  {
+    actionCategory: "Signer",
+    actor: "operator@fluid.dev",
+    action: "signer.add",
+    aiSummary: null,
+    createdAt: "2026-04-01T10:00:00.000Z",
+    id: "three",
+    ipAddress: null,
+    metadata: null,
+    riskScore: 18,
+    target: "GABC",
+  },
+];
+
+function withEnv(overrides: Partial<NodeJS.ProcessEnv>, callback: () => Promise<void>) {
+  const originalEnv = process.env;
+  process.env = { ...originalEnv, ...overrides };
+
+  return callback().finally(() => {
+    process.env = originalEnv;
+  });
+}
+
+test("normalizeAuditLogFilters trims strings and clamps risk bounds", () => {
+  assert.deepEqual(
+    normalizeAuditLogFilters({
+      actionCategory: " Auth ",
+      ipAddress: " 203.0.113 ",
+      maxRiskScore: 140,
+      minRiskScore: -10,
+    }),
+    {
+      actionCategory: "Auth",
+      ipAddress: "203.0.113",
+      maxRiskScore: 100,
+      minRiskScore: 0,
+      timePeriod: "all",
+    },
+  );
+});
+
+test("filterAuditLogs filters by IP, category, time period, and risk score", () => {
+  const filtered = filterAuditLogs(
+    entries,
+    {
+      actionCategory: "Auth",
+      ipAddress: "203.0.113",
+      minRiskScore: 80,
+      timePeriod: "24h",
+    },
+    new Date("2026-05-31T12:00:00.000Z"),
+  );
+
+  assert.deepEqual(
+    filtered.map((entry) => entry.id),
+    ["one"],
+  );
+});
+
+test("filterAuditLogs handles empty result sets", () => {
+  const filtered = filterAuditLogs(entries, {
+    actionCategory: "Tenant",
+    maxRiskScore: 10,
+  });
+
+  assert.equal(filtered.length, 0);
+});
+
+test("extractActionCategories returns sorted unique categories", () => {
+  assert.deepEqual(extractActionCategories(entries), ["API Key", "Auth", "Signer"]);
+});
+
+test("getAuditLogsData forwards detailed filters to the live audit endpoint", async () => {
+  const originalFetch = global.fetch;
+  let requestedUrl = "";
+
+  try {
+    global.fetch = (async (url) => {
+      requestedUrl = String(url);
+
+      return {
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              action: "auth.login_failed",
+              actor: "admin@fluid.dev",
+              createdAt: "2026-05-31T10:00:00.000Z",
+              id: "live-one",
+              metadata: null,
+              target: "admin@fluid.dev",
+            },
+          ],
+          limit: 25,
+          offset: 0,
+          total: 1,
+        }),
+      } as Response;
+    }) as typeof fetch;
+
+    await withEnv(
+      {
+        FLUID_ADMIN_TOKEN: "admin-token",
+        FLUID_SERVER_URL: "https://server.fluid.test/",
+      },
+      async () => {
+        const data = await getAuditLogsData(25, 0, {
+          actionCategory: "Auth",
+          ipAddress: "203.0.113",
+          minRiskScore: 50,
+          timePeriod: "7d",
+        });
+
+        assert.equal(data.source, "live");
+        assert.deepEqual(data.actionCategories, ["Auth"]);
+        assert.equal(data.items[0].actionCategory, "Auth");
+        assert.equal(data.items[0].riskScore, 0);
+        assert.match(requestedUrl, /category=Auth/);
+        assert.match(requestedUrl, /ip=203\.0\.113/);
+        assert.match(requestedUrl, /minRiskScore=50/);
+        assert.match(requestedUrl, /period=7d/);
+      },
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/admin-dashboard/lib/audit-logs-data.ts
+++ b/admin-dashboard/lib/audit-logs-data.ts
@@ -1,14 +1,18 @@
 export interface AuditLogEntry {
+  actionCategory: string;
   id: string;
   actor: string;
   action: string;
+  ipAddress: string | null;
   target: string | null;
   metadata: string | null;
   aiSummary: string | null;
   createdAt: string;
+  riskScore: number;
 }
 
 export interface AuditLogPageData {
+  actionCategories: string[];
   items: AuditLogEntry[];
   total: number;
   limit: number;
@@ -16,33 +20,64 @@ export interface AuditLogPageData {
   source: "live" | "sample";
 }
 
+export type AuditLogTimePeriod = "all" | "24h" | "7d" | "30d";
+
+export interface AuditLogFilters {
+  actionCategory?: string;
+  ipAddress?: string;
+  maxRiskScore?: number;
+  minRiskScore?: number;
+  timePeriod?: AuditLogTimePeriod;
+}
+
 const SAMPLE_AUDIT_LOGS: AuditLogEntry[] = [
   {
+    actionCategory: "Tenant",
     id: "al_001",
     actor: "admin@fluid.dev",
     action: "tenant.create",
+    ipAddress: "203.0.113.42",
     target: "tenant_001",
     metadata: JSON.stringify({ name: "Acme Corp", tier: "pro" }),
     aiSummary: "Admin created new tenant Acme Corp on the pro tier",
-    createdAt: "2024-03-28T10:30:00Z",
+    createdAt: "2026-05-31T10:30:00Z",
+    riskScore: 24,
   },
   {
+    actionCategory: "API Key",
     id: "al_002",
     actor: "system",
     action: "apikey.revoke",
+    ipAddress: "198.51.100.10",
     target: "key_abc123",
     metadata: JSON.stringify({ reason: "expired" }),
     aiSummary: "System auto-revoked expired API key",
-    createdAt: "2024-03-28T09:15:00Z",
+    createdAt: "2026-05-30T09:15:00Z",
+    riskScore: 78,
   },
   {
+    actionCategory: "Signer",
     id: "al_003",
     actor: "admin@fluid.dev",
     action: "signer.add",
+    ipAddress: "203.0.113.42",
     target: "GABCD...WXYZ",
     metadata: null,
     aiSummary: null,
-    createdAt: "2024-03-27T14:00:00Z",
+    createdAt: "2026-05-24T14:00:00Z",
+    riskScore: 46,
+  },
+  {
+    actionCategory: "Auth",
+    id: "al_004",
+    actor: "operator@fluid.dev",
+    action: "auth.login_failed",
+    ipAddress: "192.0.2.88",
+    target: "operator@fluid.dev",
+    metadata: JSON.stringify({ attempts: 5 }),
+    aiSummary: "Multiple failed sign-in attempts from a new network",
+    createdAt: "2026-04-18T08:45:00Z",
+    riskScore: 91,
   },
 ];
 
@@ -59,11 +94,11 @@ function getAdminToken() {
 export async function getAuditLogsData(
   limit = 50,
   offset = 0,
-  action?: string,
-  actor?: string,
+  filters: AuditLogFilters = {},
 ): Promise<AuditLogPageData> {
   const baseUrl = getBaseUrl();
   const token = getAdminToken();
+  const normalizedFilters = normalizeAuditLogFilters(filters);
 
   if (baseUrl && token) {
     try {
@@ -71,8 +106,21 @@ export async function getAuditLogsData(
         limit: String(limit),
         offset: String(offset),
       });
-      if (action) params.set("action", action);
-      if (actor) params.set("actor", actor);
+      if (normalizedFilters.actionCategory) {
+        params.set("category", normalizedFilters.actionCategory);
+      }
+      if (normalizedFilters.ipAddress) {
+        params.set("ip", normalizedFilters.ipAddress);
+      }
+      if (normalizedFilters.timePeriod && normalizedFilters.timePeriod !== "all") {
+        params.set("period", normalizedFilters.timePeriod);
+      }
+      if (normalizedFilters.minRiskScore !== undefined) {
+        params.set("minRiskScore", String(normalizedFilters.minRiskScore));
+      }
+      if (normalizedFilters.maxRiskScore !== undefined) {
+        params.set("maxRiskScore", String(normalizedFilters.maxRiskScore));
+      }
 
       const res = await fetch(`${baseUrl}/admin/audit-logs?${params}`, {
         headers: { "x-admin-token": token },
@@ -81,18 +129,142 @@ export async function getAuditLogsData(
 
       if (res.ok) {
         const data = await res.json();
-        return { ...data, source: "live" };
+        const items = (data.items ?? []).map(normalizeAuditLogEntry);
+        return {
+          ...data,
+          actionCategories: extractActionCategories(items),
+          items,
+          source: "live",
+        };
       }
     } catch {
       // fall through to sample
     }
   }
 
+  const filteredItems = filterAuditLogs(SAMPLE_AUDIT_LOGS, normalizedFilters);
+
   return {
-    items: SAMPLE_AUDIT_LOGS.slice(offset, offset + limit),
-    total: SAMPLE_AUDIT_LOGS.length,
+    actionCategories: extractActionCategories(SAMPLE_AUDIT_LOGS),
+    items: filteredItems.slice(offset, offset + limit),
+    total: filteredItems.length,
     limit,
     offset,
     source: "sample",
   };
+}
+
+export function normalizeAuditLogFilters(filters: AuditLogFilters): AuditLogFilters {
+  const minRiskScore = clampRiskScore(filters.minRiskScore);
+  const maxRiskScore = clampRiskScore(filters.maxRiskScore);
+
+  return {
+    actionCategory: filters.actionCategory?.trim() || undefined,
+    ipAddress: filters.ipAddress?.trim() || undefined,
+    maxRiskScore,
+    minRiskScore,
+    timePeriod: filters.timePeriod ?? "all",
+  };
+}
+
+export function filterAuditLogs(
+  entries: AuditLogEntry[],
+  filters: AuditLogFilters,
+  now = new Date(),
+): AuditLogEntry[] {
+  const normalized = normalizeAuditLogFilters(filters);
+  const startTime = getPeriodStart(normalized.timePeriod ?? "all", now);
+
+  return entries.filter((entry) => {
+    if (
+      normalized.ipAddress &&
+      !(entry.ipAddress ?? "").toLowerCase().includes(normalized.ipAddress.toLowerCase())
+    ) {
+      return false;
+    }
+
+    if (
+      normalized.actionCategory &&
+      entry.actionCategory.toLowerCase() !== normalized.actionCategory.toLowerCase()
+    ) {
+      return false;
+    }
+
+    if (startTime && new Date(entry.createdAt).getTime() < startTime.getTime()) {
+      return false;
+    }
+
+    if (
+      normalized.minRiskScore !== undefined &&
+      entry.riskScore < normalized.minRiskScore
+    ) {
+      return false;
+    }
+
+    if (
+      normalized.maxRiskScore !== undefined &&
+      entry.riskScore > normalized.maxRiskScore
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export function extractActionCategories(entries: AuditLogEntry[]): string[] {
+  return Array.from(
+    new Set(entries.map((entry) => entry.actionCategory).filter(Boolean)),
+  ).sort((a, b) => a.localeCompare(b));
+}
+
+function clampRiskScore(value: number | undefined): number | undefined {
+  if (value === undefined || Number.isNaN(value)) {
+    return undefined;
+  }
+
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+function getPeriodStart(period: AuditLogTimePeriod, now: Date): Date | null {
+  const hoursByPeriod: Record<Exclude<AuditLogTimePeriod, "all">, number> = {
+    "24h": 24,
+    "7d": 24 * 7,
+    "30d": 24 * 30,
+  };
+
+  if (period === "all") {
+    return null;
+  }
+
+  return new Date(now.getTime() - hoursByPeriod[period] * 60 * 60 * 1000);
+}
+
+function normalizeAuditLogEntry(entry: Partial<AuditLogEntry>): AuditLogEntry {
+  const action = entry.action ?? "unknown";
+
+  return {
+    id: entry.id ?? `audit-${action}-${entry.createdAt ?? "unknown"}`,
+    actor: entry.actor ?? "unknown",
+    action,
+    actionCategory: entry.actionCategory || deriveActionCategory(action),
+    aiSummary: entry.aiSummary ?? null,
+    createdAt: entry.createdAt ?? new Date(0).toISOString(),
+    ipAddress: entry.ipAddress ?? null,
+    metadata: entry.metadata ?? null,
+    riskScore: clampRiskScore(entry.riskScore) ?? 0,
+    target: entry.target ?? null,
+  };
+}
+
+function deriveActionCategory(action: string): string {
+  const namespace = action.split(".")[0]?.trim();
+
+  if (!namespace) {
+    return "Other";
+  }
+
+  return namespace
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }

--- a/admin-dashboard/lib/server-log-stream.test.ts
+++ b/admin-dashboard/lib/server-log-stream.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createServerLogEvent,
+  formatSseEvent,
+  isServerLogLevel,
+  parseServerLogEvent,
+} from "./server-log-stream.ts";
+
+test("formatSseEvent emits named SSE events with optional ids", () => {
+  const event = formatSseEvent("log", { message: "ready" }, "log_1");
+
+  assert.equal(event, 'event: log\nid: log_1\ndata: {"message":"ready"}\n\n');
+});
+
+test("formatSseEvent sanitizes event and id fields", () => {
+  const event = formatSseEvent("log\nretry: 1", undefined, "log_1\rdata: injected");
+
+  assert.equal(event, "event: log retry: 1\nid: log_1 data: injected\ndata: null\n\n");
+});
+
+test("createServerLogEvent fills id and timestamp defaults", () => {
+  const event = createServerLogEvent({
+    level: "info",
+    message: "stream connected",
+    service: "admin-dashboard",
+  });
+
+  assert.match(event.id, /^log_/);
+  assert.equal(event.level, "info");
+  assert.equal(event.message, "stream connected");
+  assert.equal(event.service, "admin-dashboard");
+  assert.doesNotThrow(() => new Date(event.timestamp).toISOString());
+});
+
+test("parseServerLogEvent accepts valid events", () => {
+  const parsed = parseServerLogEvent(
+    JSON.stringify({
+      id: "log_1",
+      level: "warn",
+      message: "upstream unavailable",
+      metadata: { retry: true },
+      service: "admin-dashboard",
+      timestamp: "2026-05-31T12:00:00.000Z",
+    }),
+  );
+
+  assert.deepEqual(parsed, {
+    id: "log_1",
+    level: "warn",
+    message: "upstream unavailable",
+    metadata: { retry: true },
+    service: "admin-dashboard",
+    timestamp: "2026-05-31T12:00:00.000Z",
+  });
+});
+
+test("parseServerLogEvent rejects malformed and unknown-level payloads", () => {
+  assert.equal(parseServerLogEvent("{"), null);
+  assert.equal(
+    parseServerLogEvent(
+      JSON.stringify({
+        id: "log_1",
+        level: "fatal",
+        message: "bad level",
+        service: "server",
+        timestamp: "2026-05-31T12:00:00.000Z",
+      }),
+    ),
+    null,
+  );
+});
+
+test("isServerLogLevel recognizes supported log levels", () => {
+  assert.equal(isServerLogLevel("debug"), true);
+  assert.equal(isServerLogLevel("info"), true);
+  assert.equal(isServerLogLevel("warn"), true);
+  assert.equal(isServerLogLevel("error"), true);
+  assert.equal(isServerLogLevel("trace"), false);
+});

--- a/admin-dashboard/lib/server-log-stream.ts
+++ b/admin-dashboard/lib/server-log-stream.ts
@@ -1,0 +1,75 @@
+export type ServerLogLevel = "debug" | "info" | "warn" | "error";
+
+export interface ServerLogEvent {
+  id: string;
+  level: ServerLogLevel;
+  message: string;
+  service: string;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function formatSseEvent(event: string, data: unknown, id?: string): string {
+  const lines = [`event: ${sanitizeSseField(event)}`];
+
+  if (id) {
+    lines.push(`id: ${sanitizeSseField(id)}`);
+  }
+
+  for (const line of (JSON.stringify(data) ?? "null").split(/\r?\n/)) {
+    lines.push(`data: ${line}`);
+  }
+
+  return `${lines.join("\n")}\n\n`;
+}
+
+export function createServerLogEvent(
+  input: Omit<ServerLogEvent, "id" | "timestamp"> & Partial<Pick<ServerLogEvent, "id" | "timestamp">>,
+): ServerLogEvent {
+  return {
+    id: input.id ?? `log_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    level: input.level,
+    message: input.message,
+    metadata: input.metadata,
+    service: input.service,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+  };
+}
+
+export function parseServerLogEvent(value: string): ServerLogEvent | null {
+  try {
+    const parsed = JSON.parse(value) as Partial<ServerLogEvent>;
+
+    if (
+      typeof parsed.id !== "string" ||
+      !isServerLogLevel(parsed.level) ||
+      typeof parsed.message !== "string" ||
+      typeof parsed.service !== "string" ||
+      typeof parsed.timestamp !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      id: parsed.id,
+      level: parsed.level,
+      message: parsed.message,
+      metadata:
+        parsed.metadata && typeof parsed.metadata === "object" && !Array.isArray(parsed.metadata)
+          ? parsed.metadata
+          : undefined,
+      service: parsed.service,
+      timestamp: parsed.timestamp,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isServerLogLevel(value: unknown): value is ServerLogLevel {
+  return value === "debug" || value === "info" || value === "warn" || value === "error";
+}
+
+function sanitizeSseField(value: string): string {
+  return value.replace(/[\r\n]/g, " ");
+}

--- a/admin-dashboard/package.json
+++ b/admin-dashboard/package.json
@@ -11,7 +11,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:watch": "vitest",
     "format:check": "echo \"No format check configured\"",
-    "test:unit": "node --test --experimental-test-isolation=none --experimental-strip-types lib/portal-links.test.ts lib/theme.test.ts src/compliance/__tests__/compliance.test.ts src/fees/__tests__/region-congestion-config.test.ts src/fees/__tests__/localized-fee-estimator.test.ts src/i18n/__tests__/i18n.test.ts",
+    "test:unit": "node --test --experimental-test-isolation=none --experimental-strip-types lib/audit-logs-data.test.ts lib/portal-links.test.ts lib/theme.test.ts src/compliance/__tests__/compliance.test.ts src/fees/__tests__/region-congestion-config.test.ts src/fees/__tests__/localized-fee-estimator.test.ts src/i18n/__tests__/i18n.test.ts",
     "test:integration": "node --test --experimental-test-isolation=none --experimental-strip-types lib/theme.integration.test.ts src/compliance/__tests__/compliance.integration.test.ts",
     "test:e2e": "playwright test",
     "docs": "typedoc",

--- a/admin-dashboard/package.json
+++ b/admin-dashboard/package.json
@@ -11,7 +11,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:watch": "vitest",
     "format:check": "echo \"No format check configured\"",
-    "test:unit": "node --test --experimental-test-isolation=none --experimental-strip-types lib/audit-logs-data.test.ts lib/portal-links.test.ts lib/theme.test.ts src/compliance/__tests__/compliance.test.ts src/fees/__tests__/region-congestion-config.test.ts src/fees/__tests__/localized-fee-estimator.test.ts src/i18n/__tests__/i18n.test.ts",
+    "test:unit": "node --test --experimental-test-isolation=none --experimental-strip-types lib/audit-logs-data.test.ts lib/server-log-stream.test.ts lib/portal-links.test.ts lib/theme.test.ts src/compliance/__tests__/compliance.test.ts src/fees/__tests__/region-congestion-config.test.ts src/fees/__tests__/localized-fee-estimator.test.ts src/i18n/__tests__/i18n.test.ts",
     "test:integration": "node --test --experimental-test-isolation=none --experimental-strip-types lib/theme.integration.test.ts src/compliance/__tests__/compliance.integration.test.ts",
     "test:e2e": "playwright test",
     "docs": "typedoc",

--- a/fluid-server/src/lib.rs
+++ b/fluid-server/src/lib.rs
@@ -584,6 +584,62 @@ mod tests {
     }
 
     #[test]
+    fn verify_api_key_fuzzes_malformed_unicode_and_binary_like_inputs() {
+        let expected = "sk_live_0123456789abcdef";
+        let malformed_inputs = vec![
+            "\0".to_string(),
+            "\0\0\0".to_string(),
+            "sk_live_0123456789abcdef\0".to_string(),
+            "fluid\nkey".to_string(),
+            "fluid\r\nx-api-key: injected".to_string(),
+            "fluid\tkey".to_string(),
+            "   sk_live_0123456789abcdef   ".to_string(),
+            "sk_live_\u{202e}fedcba9876543210".to_string(),
+            "sk_live_\u{200d}\u{fe0f}".to_string(),
+            "🔑".to_string(),
+            "fluid-🔐-demo-key".to_string(),
+            "密钥".to_string(),
+            "مفتاح".to_string(),
+            "कुंजी".to_string(),
+            "\u{7f}".to_string(),
+            "\u{80}".to_string(),
+            "\u{fffd}".to_string(),
+            "\u{10ffff}".to_string(),
+            "A".repeat(8_192),
+            "sk_live_".repeat(1_024),
+        ];
+
+        for candidate in malformed_inputs {
+            let result = std::panic::catch_unwind(|| verify_api_key(&candidate, expected));
+            assert!(
+                result.is_ok(),
+                "verify_api_key panicked for candidate {:?}",
+                candidate
+            );
+            assert!(
+                !result.unwrap(),
+                "malformed candidate {:?} unexpectedly matched",
+                candidate
+            );
+        }
+    }
+
+    #[test]
+    fn verify_api_key_fuzzes_all_byte_values_without_panics() {
+        let expected = "sk_live_0123456789abcdef";
+
+        for byte in 0u8..=u8::MAX {
+            let candidate = char::from(byte).to_string();
+            let result = std::panic::catch_unwind(|| verify_api_key(&candidate, expected));
+            assert!(
+                result.is_ok(),
+                "verify_api_key panicked for byte value {byte}"
+            );
+            assert!(!result.unwrap(), "byte value {byte} unexpectedly matched");
+        }
+    }
+
+    #[test]
     fn envelope_signature_count_counts_all_envelope_variants() {
         let mut env = parse_transaction_envelope(UNSIGNED_XDR).unwrap();
         assert_eq!(envelope_signature_count(&env), 0);

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
     "benchmark:signing": "npm run native:build && ts-node src/benchmarks/signing.ts",
     "benchmark:migration": "ts-node src/benchmarks/migration.ts",
     "benchmark:network": "ts-node src/benchmarks/network_performance_test.ts",
+    "parity:errors": "ts-node scripts/errorResponseParityCheck.ts",
     "parity:rust": "npm run native:build && powershell -NoProfile -Command \"Get-Process fluid-server -ErrorAction SilentlyContinue | Stop-Process -Force; exit 0\" && cargo build -q --manifest-path ..\\fluid-server\\Cargo.toml && ts-node scripts/parityCheck.ts",
     "test:signer-pool": "npm run native:build && node --test -r ts-node/register src/signing/signerPool.test.ts",
     "grpc-engine": "cargo run --manifest-path Cargo.toml --bin grpc_engine",

--- a/server/scripts/errorResponseParityCheck.ts
+++ b/server/scripts/errorResponseParityCheck.ts
@@ -1,0 +1,44 @@
+import { compareErrorParity, defaultErrorParityCases } from "../src/test/errorResponseParity";
+
+const nodeBaseUrl = process.env.NODE_PARITY_BASE_URL ?? "http://127.0.0.1:3000";
+const rustBaseUrl = process.env.RUST_PARITY_BASE_URL ?? "http://127.0.0.1:3001";
+
+async function main(): Promise<void> {
+  const results = await compareErrorParity(nodeBaseUrl, rustBaseUrl, defaultErrorParityCases);
+  const failures = results.filter((result) => result.mismatches.length > 0);
+
+  for (const result of results) {
+    if (result.mismatches.length === 0) {
+      console.log(`ERROR_PARITY_OK ${result.caseName}`);
+      continue;
+    }
+
+    console.error(`ERROR_PARITY_FAIL ${result.caseName}`);
+    console.error(
+      JSON.stringify(
+        {
+          mismatches: result.mismatches,
+          node: result.node,
+          rust: result.rust,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  if (failures.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `ERROR_PARITY_COMPLETE checked=${results.length} node=${nodeBaseUrl} rust=${rustBaseUrl}`,
+  );
+}
+
+main().catch((error) => {
+  process.exitCode = 1;
+  console.error("ERROR_PARITY_ERROR");
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+});

--- a/server/src/test/errorResponseParity.test.ts
+++ b/server/src/test/errorResponseParity.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  captureErrorResponse,
+  compareErrorParity,
+  compareErrorResponses,
+  normalizeErrorSnapshot,
+  sortJson,
+} from "./errorResponseParity";
+
+describe("error response parity helpers", () => {
+  it("sorts JSON objects recursively for stable comparisons", () => {
+    expect(
+      sortJson({
+        z: 1,
+        a: [{ d: true, b: "value" }],
+      }),
+    ).toEqual({
+      a: [{ b: "value", d: true }],
+      z: 1,
+    });
+  });
+
+  it("normalizes content-type parameters and body key order", () => {
+    expect(
+      normalizeErrorSnapshot({
+        body: { error: "Invalid API key.", code: "AUTH_FAILED" },
+        contentType: "application/json; charset=utf-8",
+        status: 403,
+      }),
+    ).toEqual({
+      body: { code: "AUTH_FAILED", error: "Invalid API key." },
+      contentType: "application/json",
+      status: 403,
+    });
+  });
+
+  it("reports no mismatches when status, content type, and JSON body match", () => {
+    const result = compareErrorResponses(
+      "invalid-api-key",
+      {
+        body: { error: "Invalid API key.", code: "AUTH_FAILED" },
+        contentType: "application/json",
+        status: 403,
+      },
+      {
+        body: { code: "AUTH_FAILED", error: "Invalid API key." },
+        contentType: "application/json; charset=utf-8",
+        status: 403,
+      },
+    );
+
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it("reports field-level mismatches for parity failures", () => {
+    const result = compareErrorResponses(
+      "missing-api-key",
+      {
+        body: { code: "AUTH_FAILED", error: "API key required" },
+        contentType: "application/json",
+        status: 401,
+      },
+      {
+        body: { code: "AUTH_FAILED", error: "Missing API key." },
+        contentType: "text/plain",
+        status: 403,
+      },
+    );
+
+    expect(result.mismatches).toEqual([
+      {
+        caseName: "missing-api-key",
+        field: "status",
+        node: 401,
+        rust: 403,
+      },
+      {
+        caseName: "missing-api-key",
+        field: "contentType",
+        node: "application/json",
+        rust: "text/plain",
+      },
+      {
+        caseName: "missing-api-key",
+        field: "body",
+        node: { code: "AUTH_FAILED", error: "API key required" },
+        rust: { code: "AUTH_FAILED", error: "Missing API key." },
+      },
+    ]);
+  });
+
+  it("captures non-JSON response bodies without throwing", async () => {
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      headers: {
+        get: vi.fn().mockReturnValue("text/plain"),
+      },
+      status: 500,
+      text: vi.fn().mockResolvedValue("server exploded"),
+    } as any);
+
+    await expect(
+      captureErrorResponse("http://node.local", {
+        method: "GET",
+        name: "plain-text-error",
+        path: "/boom",
+      }),
+    ).resolves.toEqual({
+      body: "server exploded",
+      contentType: "text/plain",
+      status: 500,
+    });
+
+    global.fetch = originalFetch;
+  });
+
+  it("compares every configured case against both servers", async () => {
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      headers: {
+        get: vi.fn().mockReturnValue("application/json"),
+      },
+      status: 404,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ code: "NOT_FOUND", error: "missing" })),
+    } as any);
+
+    const results = await compareErrorParity("http://node.local", "http://rust.local", [
+      {
+        method: "GET",
+        name: "unknown-route",
+        path: "/missing",
+      },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].mismatches).toEqual([]);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    global.fetch = originalFetch;
+  });
+});

--- a/server/src/test/errorResponseParity.ts
+++ b/server/src/test/errorResponseParity.ts
@@ -1,0 +1,196 @@
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface ErrorResponseSnapshot {
+  body: JsonValue | string;
+  contentType: string | null;
+  status: number;
+}
+
+export interface ErrorParityCase {
+  body?: string;
+  headers?: Record<string, string>;
+  method: string;
+  name: string;
+  path: string;
+}
+
+export interface ErrorParityMismatch {
+  caseName: string;
+  field: "status" | "contentType" | "body";
+  node: JsonValue | string | number | null;
+  rust: JsonValue | string | number | null;
+}
+
+export interface ErrorParityResult {
+  caseName: string;
+  mismatches: ErrorParityMismatch[];
+  node: ErrorResponseSnapshot;
+  rust: ErrorResponseSnapshot;
+}
+
+export const defaultErrorParityCases: ErrorParityCase[] = [
+  {
+    body: JSON.stringify({ xdr: "AAAA" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+    name: "missing-api-key",
+    path: "/fee-bump",
+  },
+  {
+    body: JSON.stringify({ xdr: "AAAA" }),
+    headers: { "content-type": "application/json", "x-api-key": "bad-key" },
+    method: "POST",
+    name: "invalid-api-key",
+    path: "/fee-bump",
+  },
+  {
+    body: JSON.stringify({ xdr: "" }),
+    headers: { "content-type": "application/json", "x-api-key": "fluid-pro-demo-key" },
+    method: "POST",
+    name: "empty-xdr",
+    path: "/fee-bump",
+  },
+  {
+    body: JSON.stringify({ xdr: "not-base64", submit: false }),
+    headers: { "content-type": "application/json", "x-api-key": "fluid-pro-demo-key" },
+    method: "POST",
+    name: "malformed-xdr",
+    path: "/fee-bump",
+  },
+  {
+    body: "{",
+    headers: { "content-type": "application/json", "x-api-key": "fluid-pro-demo-key" },
+    method: "POST",
+    name: "malformed-json",
+    path: "/fee-bump",
+  },
+  {
+    method: "GET",
+    name: "unknown-route",
+    path: "/__parity_missing_route__",
+  },
+];
+
+export function sortJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entryValue]) => [key, sortJson(entryValue as JsonValue)]),
+    );
+  }
+
+  return value;
+}
+
+export function normalizeErrorSnapshot(snapshot: ErrorResponseSnapshot): ErrorResponseSnapshot {
+  const contentType = snapshot.contentType?.split(";")[0]?.trim().toLowerCase() ?? null;
+
+  return {
+    body:
+      typeof snapshot.body === "string"
+        ? snapshot.body
+        : sortJson(snapshot.body),
+    contentType,
+    status: snapshot.status,
+  };
+}
+
+export function compareErrorResponses(
+  caseName: string,
+  nodeSnapshot: ErrorResponseSnapshot,
+  rustSnapshot: ErrorResponseSnapshot,
+): ErrorParityResult {
+  const node = normalizeErrorSnapshot(nodeSnapshot);
+  const rust = normalizeErrorSnapshot(rustSnapshot);
+  const mismatches: ErrorParityMismatch[] = [];
+
+  if (node.status !== rust.status) {
+    mismatches.push({
+      caseName,
+      field: "status",
+      node: node.status,
+      rust: rust.status,
+    });
+  }
+
+  if (node.contentType !== rust.contentType) {
+    mismatches.push({
+      caseName,
+      field: "contentType",
+      node: node.contentType,
+      rust: rust.contentType,
+    });
+  }
+
+  if (JSON.stringify(node.body) !== JSON.stringify(rust.body)) {
+    mismatches.push({
+      caseName,
+      field: "body",
+      node: node.body,
+      rust: rust.body,
+    });
+  }
+
+  return {
+    caseName,
+    mismatches,
+    node,
+    rust,
+  };
+}
+
+export async function captureErrorResponse(
+  baseUrl: string,
+  parityCase: ErrorParityCase,
+): Promise<ErrorResponseSnapshot> {
+  const response = await fetch(new URL(parityCase.path, baseUrl), {
+    body: parityCase.body,
+    headers: parityCase.headers,
+    method: parityCase.method,
+  });
+  const text = await response.text();
+
+  try {
+    return {
+      body: JSON.parse(text) as JsonValue,
+      contentType: response.headers.get("content-type"),
+      status: response.status,
+    };
+  } catch {
+    return {
+      body: text,
+      contentType: response.headers.get("content-type"),
+      status: response.status,
+    };
+  }
+}
+
+export async function compareErrorParity(
+  nodeBaseUrl: string,
+  rustBaseUrl: string,
+  parityCases: ErrorParityCase[] = defaultErrorParityCases,
+): Promise<ErrorParityResult[]> {
+  const results: ErrorParityResult[] = [];
+
+  for (const parityCase of parityCases) {
+    const [node, rust] = await Promise.all([
+      captureErrorResponse(nodeBaseUrl, parityCase),
+      captureErrorResponse(rustBaseUrl, parityCase),
+    ]);
+
+    results.push(compareErrorResponses(parityCase.name, node, rust));
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- Added fuzz-style API key validation tests for malformed strings, emojis, Unicode, null bytes, and binary-like inputs in `fluid-server`.
- Added automated JSON error response parity comparison tooling for Node vs Rust servers in `server`.
- Added detailed audit log filtering by IP address, action category, time period, and risk score in `admin-dashboard`.
- Added authenticated SSE server log streaming endpoint and dashboard log viewer in `admin-dashboard`.

## Related Issues
Closes #729 
Closes #739 
Closes #724 
Closes #744