### PR TITLE
feat: theme toggle, api-key usage charts, settings panel, leaderboard…

### DIFF
--- a/admin-dashboard/app/admin/api-keys/page.tsx
+++ b/admin-dashboard/app/admin/api-keys/page.tsx
@@ -1,31 +1,34 @@
 import { auth } from "@/auth";
 import Link from "next/link";
 import { ApiKeysTable } from "@/components/dashboard/ApiKeysTable";
+import { ApiKeyUsageCharts } from "@/components/dashboard/ApiKeyUsageCharts";
 import { getApiKeysPageData } from "@/lib/api-keys-data";
+import { buildApiKeyUsageStats } from "@/lib/api-key-usage-data";
 
 export default async function AdminApiKeysPage() {
   const session = await auth();
   const { keys, source, serverUrl, adminToken } = await getApiKeysPageData();
+  const usageStats = buildApiKeyUsageStats(keys);
 
   return (
-    <main className="min-h-screen bg-slate-100">
-      <div className="border-b border-slate-200 bg-white/90 backdrop-blur">
+    <main className="min-h-screen bg-background">
+      <div className="border-b border-border/50 bg-background/90 backdrop-blur sticky top-0 z-10">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-sky-600">
+              <p className="text-[10px] font-black uppercase tracking-[0.3em] text-primary">
                 Fluid Admin
               </p>
-              <h1 className="mt-2 text-3xl font-bold text-slate-900">
+              <h1 className="mt-2 text-3xl font-bold text-foreground">
                 API Key Management
               </h1>
-              <p className="mt-2 max-w-2xl text-sm text-slate-600">
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
                 Revoke keys immediately if a key is leaked or a dApp is abusive.
               </p>
             </div>
             <div className="flex items-center gap-4">
-              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-                <div className="font-medium text-slate-900">
+              <div className="rounded-2xl border border-border/50 bg-card px-4 py-3 text-sm text-muted-foreground">
+                <div className="font-medium text-foreground">
                   {session?.user?.email}
                 </div>
                 <div>
@@ -34,7 +37,7 @@ export default async function AdminApiKeysPage() {
               </div>
               <Link
                 href="/admin/dashboard"
-                className="inline-flex min-h-10 items-center justify-center rounded-full border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                className="inline-flex min-h-10 items-center justify-center rounded-full border border-border/50 bg-card px-4 text-sm font-semibold text-foreground transition hover:bg-muted"
               >
                 Back to dashboard
               </Link>
@@ -43,12 +46,30 @@ export default async function AdminApiKeysPage() {
         </div>
       </div>
 
-      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
         <ApiKeysTable
           initialKeys={keys}
           serverUrl={serverUrl}
           adminToken={adminToken}
         />
+
+        <section aria-labelledby="usage-charts-heading">
+          <h2
+            id="usage-charts-heading"
+            className="mb-4 text-xl font-bold tracking-tight text-foreground"
+          >
+            Usage Analytics
+          </h2>
+          <p className="mb-6 text-sm text-muted-foreground">
+            Per-key performance metrics including request counts, failure rates, and fee cost.
+            {source === "sample" && (
+              <span className="ml-2 font-medium text-amber-600">
+                Showing sample data — connect a live server to see real metrics.
+              </span>
+            )}
+          </p>
+          <ApiKeyUsageCharts stats={usageStats} />
+        </section>
       </div>
     </main>
   );

--- a/admin-dashboard/app/admin/settings/page.tsx
+++ b/admin-dashboard/app/admin/settings/page.tsx
@@ -1,126 +1,185 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
-import { useEffect } from "react";
+import {
+  DEFAULT_SETTINGS,
+  SETTINGS_FIELDS,
+  type SettingsConfig,
+} from "@/lib/settings-config";
 
 const schema = z.object({
-  base_fee: z.number().min(0),
-  fee_multiplier: z.number().min(1),
-  low_balance_threshold: z.number().min(0),
+  base_fee: z.number().min(0, "Must be 0 or greater"),
+  fee_multiplier: z.number().min(1, "Must be at least 1"),
+  low_balance_threshold: z.number().min(0, "Must be 0 or greater"),
+  rate_limit_per_minute: z.number().min(1, "Must be at least 1"),
+  max_wallets_per_tenant: z.number().min(1, "Must be at least 1"),
+  max_tx_per_hour: z.number().min(1, "Must be at least 1"),
 });
 
+type FormValues = z.infer<typeof schema>;
+
 export default function SettingsPage() {
-const form = useForm({
-  resolver: zodResolver(schema),
-  defaultValues: {
-    base_fee: 100,
-    fee_multiplier: 2,
-    low_balance_threshold: 1000,
-  },
-});
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const {
     register,
     handleSubmit,
-    setValue,
-    formState: { errors, isSubmitting },
-  } = form;
+    reset,
+    formState: { errors, isSubmitting, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: DEFAULT_SETTINGS,
+  });
 
   useEffect(() => {
-    fetch("/admin/settings")
-      .then((res) => res.json())
-      .then((data) => {
-        setValue("base_fee", data.base_fee);
-        setValue("fee_multiplier", data.fee_multiplier);
-        setValue("low_balance_threshold", data.low_balance_threshold);
+    fetch("/api/admin/settings")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data: Partial<SettingsConfig>) => {
+        reset({ ...DEFAULT_SETTINGS, ...data });
+      })
+      .catch(() => {
+        setLoadError(
+          "Could not reach the settings endpoint — showing defaults. Changes will still be persisted when you save.",
+        );
       });
-  }, []);
+  }, [reset]);
 
-  const onSubmit = async (data: any) => {
-    const res = await fetch("/admin/settings", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(data),
-    });
+  const onSubmit = async (data: FormValues) => {
+    try {
+      const res = await fetch("/api/admin/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
 
-    if (res.ok) {
-      toast.success("Settings saved successfully");
-    } else {
-      toast.error("Failed to save settings");
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? `Request failed (${res.status})`);
+      }
+
+      toast.success("Settings saved and hot-reloaded.");
+      reset(data);
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Failed to save settings.");
     }
   };
 
-return (
-  <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
-    <div className="mx-auto max-w-2xl">
-      <h1 className="mb-6 text-3xl font-bold">Settings</h1>
+  function handleReset() {
+    reset(DEFAULT_SETTINGS);
+    toast.info("Form reset to factory defaults. Save to apply.");
+  }
 
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className="rounded-xl border border-slate-800 bg-slate-900 p-6"
-      >
-        {/* Base Fee */}
-        <div className="mb-5">
-          <label className="mb-2 block text-sm text-slate-300">Base Fee</label>
-          <input
-            type="number"
-            className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-white outline-none focus:border-blue-500"
-            {...register("base_fee", { valueAsNumber: true })}
-          />
-          {errors.base_fee && (
-            <p className="mt-1 text-sm text-red-400">
-              {errors.base_fee.message}
-            </p>
-          )}
+  const sections: Array<{ heading: string; keys: Array<keyof SettingsConfig> }> = [
+    { heading: "Fee Configuration", keys: ["base_fee", "fee_multiplier", "low_balance_threshold"] },
+    { heading: "Rate & Quota Limits", keys: ["rate_limit_per_minute", "max_wallets_per_tenant", "max_tx_per_hour"] },
+  ];
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-2xl">
+        <div className="mb-8">
+          <p className="text-[10px] font-black uppercase tracking-[0.3em] text-primary">
+            Fluid Admin
+          </p>
+          <h1 className="mt-2 text-3xl font-bold text-foreground">Settings</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Hot-reload runtime variables without restarting the server. Changes take effect immediately on save.
+          </p>
         </div>
 
-        {/* Fee Multiplier */}
-        <div className="mb-5">
-          <label className="mb-2 block text-sm text-slate-300">
-            Fee Multiplier
-          </label>
-          <input
-            type="number"
-            step="0.1"
-            className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-white outline-none focus:border-blue-500"
-            {...register("fee_multiplier", { valueAsNumber: true })}
-          />
-          {errors.fee_multiplier && (
-            <p className="mt-1 text-sm text-red-400">
-              {errors.fee_multiplier.message}
-            </p>
-          )}
-        </div>
+        {loadError && (
+          <div
+            role="alert"
+            className="mb-6 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          >
+            {loadError}
+          </div>
+        )}
 
-        {/* Threshold */}
-        <div className="mb-6">
-          <label className="mb-2 block text-sm text-slate-300">
-            Low Balance Threshold
-          </label>
-          <input
-            type="number"
-            className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-white outline-none focus:border-blue-500"
-            {...register("low_balance_threshold", { valueAsNumber: true })}
-          />
-          {errors.low_balance_threshold && (
-            <p className="mt-1 text-sm text-red-400">
-              {errors.low_balance_threshold.message}
-            </p>
-          )}
-        </div>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-8" noValidate>
+          {sections.map((section) => {
+            const fields = SETTINGS_FIELDS.filter((f) =>
+              section.keys.includes(f.key),
+            );
 
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="w-full rounded-md bg-blue-600 py-2 font-semibold hover:bg-blue-500 disabled:opacity-60"
-        >
-          {isSubmitting ? "Saving..." : "Save Changes"}
-        </button>
-      </form>
-    </div>
-  </main>
-);
+            return (
+              <div
+                key={section.heading}
+                className="overflow-hidden rounded-3xl border border-border/50 bg-card shadow-sm"
+              >
+                <div className="border-b border-border/50 px-6 py-4">
+                  <h2 className="text-base font-semibold text-foreground">
+                    {section.heading}
+                  </h2>
+                </div>
+                <div className="divide-y divide-border/50">
+                  {fields.map((field) => (
+                    <div key={field.key} className="px-6 py-5">
+                      <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                        <div className="flex-1">
+                          <label
+                            htmlFor={field.key}
+                            className="block text-sm font-semibold text-foreground"
+                          >
+                            {field.label}
+                            {field.unit && (
+                              <span className="ml-2 rounded-full bg-muted px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                                {field.unit}
+                              </span>
+                            )}
+                          </label>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {field.description}
+                          </p>
+                        </div>
+                        <div className="w-full sm:w-36">
+                          <input
+                            id={field.key}
+                            type="number"
+                            step={field.step}
+                            min={field.min}
+                            className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition focus:border-primary focus:ring-1 focus:ring-primary"
+                            {...register(field.key, { valueAsNumber: true })}
+                          />
+                          {errors[field.key] && (
+                            <p className="mt-1 text-xs text-rose-600">
+                              {errors[field.key]?.message}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-between">
+            <button
+              type="button"
+              onClick={handleReset}
+              className="inline-flex min-h-10 items-center justify-center rounded-full border border-border/50 bg-card px-5 text-sm font-semibold text-foreground transition hover:bg-muted"
+            >
+              Reset to defaults
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting || !isDirty}
+              className="inline-flex min-h-10 items-center justify-center rounded-full bg-primary px-6 text-sm font-bold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+            >
+              {isSubmitting ? "Saving…" : "Save & hot-reload"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
+  );
 }

--- a/admin-dashboard/components/dashboard/ApiKeyUsageCharts.test.tsx
+++ b/admin-dashboard/components/dashboard/ApiKeyUsageCharts.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiKeyUsageCharts } from "@/components/dashboard/ApiKeyUsageCharts";
+import type { ApiKeyUsageStat } from "@/lib/api-key-usage-data";
+
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual<typeof import("recharts")>("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", { "data-testid": "responsive-container" }, children),
+  };
+});
+
+const SAMPLE_STATS: ApiKeyUsageStat[] = [
+  {
+    keyId: "key-01",
+    label: "flud…1234",
+    tenantId: "tenant-a",
+    successCount: 1150,
+    failedCount: 50,
+    totalCount: 1200,
+    failureRatePct: 4,
+    totalCostStroops: 115_000,
+  },
+  {
+    keyId: "key-02",
+    label: "flud…5678",
+    tenantId: "tenant-b",
+    successCount: 2200,
+    failedCount: 100,
+    totalCount: 2300,
+    failureRatePct: 4,
+    totalCostStroops: 220_000,
+  },
+];
+
+describe("ApiKeyUsageCharts", () => {
+  it("renders three chart sections for non-empty stats", () => {
+    render(React.createElement(ApiKeyUsageCharts, { stats: SAMPLE_STATS }));
+    expect(screen.getByText("Requests per Key")).toBeInTheDocument();
+    expect(screen.getByText("Failure Rate (%)")).toBeInTheDocument();
+    expect(screen.getByText("Cost per Key (stroops)")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when stats array is empty", () => {
+    render(React.createElement(ApiKeyUsageCharts, { stats: [] }));
+    expect(
+      screen.getByText("No usage data available for the current key set."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render charts in empty state", () => {
+    render(React.createElement(ApiKeyUsageCharts, { stats: [] }));
+    expect(screen.queryByText("Requests per Key")).not.toBeInTheDocument();
+  });
+
+  it("renders chart containers for each chart section", () => {
+    render(React.createElement(ApiKeyUsageCharts, { stats: SAMPLE_STATS }));
+    const containers = screen.getAllByTestId("responsive-container");
+    expect(containers.length).toBe(3);
+  });
+});

--- a/admin-dashboard/components/dashboard/ApiKeyUsageCharts.tsx
+++ b/admin-dashboard/components/dashboard/ApiKeyUsageCharts.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { ApiKeyUsageStat } from "@/lib/api-key-usage-data";
+
+interface ApiKeyUsageChartsProps {
+  stats: ApiKeyUsageStat[];
+}
+
+const CHART_MARGIN = { top: 5, right: 12, left: 0, bottom: 5 };
+
+const TOOLTIP_STYLE = {
+  borderRadius: "0.5rem",
+  border: "1px solid var(--border)",
+  background: "var(--card)",
+  color: "var(--foreground)",
+  fontSize: "12px",
+};
+
+const TICK_STYLE = { fontSize: 11, fill: "var(--muted-foreground)" };
+
+export function ApiKeyUsageCharts({ stats }: ApiKeyUsageChartsProps) {
+  if (stats.length === 0) {
+    return (
+      <div className="rounded-3xl border border-border/50 bg-card px-5 py-10 text-center text-sm text-muted-foreground">
+        No usage data available for the current key set.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Requests per key */}
+      <div className="overflow-hidden rounded-3xl border border-border/50 bg-card shadow-sm">
+        <div className="border-b border-border/50 px-5 py-4">
+          <h2 className="text-lg font-semibold text-foreground">Requests per Key</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Successful and failed request counts broken down by API key.
+          </p>
+        </div>
+        <div className="p-5">
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={stats} margin={CHART_MARGIN}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+              <XAxis dataKey="label" tick={TICK_STYLE} />
+              <YAxis tick={TICK_STYLE} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} />
+              <Legend wrapperStyle={{ fontSize: "12px" }} />
+              <Bar dataKey="successCount" name="Success" fill="#10b981" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="failedCount" name="Failed" fill="#f43f5e" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Failure rate */}
+      <div className="overflow-hidden rounded-3xl border border-border/50 bg-card shadow-sm">
+        <div className="border-b border-border/50 px-5 py-4">
+          <h2 className="text-lg font-semibold text-foreground">Failure Rate (%)</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Percentage of requests that failed per key. Elevated rates may signal abuse or mis-configuration.
+          </p>
+        </div>
+        <div className="p-5">
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={stats} margin={CHART_MARGIN}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+              <XAxis dataKey="label" tick={TICK_STYLE} />
+              <YAxis
+                tick={TICK_STYLE}
+                tickFormatter={(v: number) => `${v}%`}
+                domain={[0, 100]}
+              />
+              <Tooltip
+                formatter={(value: number) => [`${value}%`, "Failure rate"]}
+                contentStyle={TOOLTIP_STYLE}
+              />
+              <Bar
+                dataKey="failureRatePct"
+                name="Failure rate"
+                fill="#f59e0b"
+                radius={[4, 4, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Cost per key */}
+      <div className="overflow-hidden rounded-3xl border border-border/50 bg-card shadow-sm">
+        <div className="border-b border-border/50 px-5 py-4">
+          <h2 className="text-lg font-semibold text-foreground">Cost per Key (stroops)</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Estimated network fee cost attributed to each API key based on sponsored transactions.
+          </p>
+        </div>
+        <div className="p-5">
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={stats} margin={CHART_MARGIN}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+              <XAxis dataKey="label" tick={TICK_STYLE} />
+              <YAxis tick={TICK_STYLE} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} />
+              <Bar
+                dataKey="totalCostStroops"
+                name="Cost (stroops)"
+                fill="#6366f1"
+                radius={[4, 4, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/admin-dashboard/components/dashboard/UsageLeaderboard.tsx
+++ b/admin-dashboard/components/dashboard/UsageLeaderboard.tsx
@@ -1,5 +1,9 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import type { TenantUsageRow } from "@/components/dashboard/types";
+import { exportLeaderboardToCSV, exportLeaderboardToPDF } from "@/lib/export-leaderboard";
 
 interface UsageLeaderboardProps {
   rows: TenantUsageRow[];
@@ -23,6 +27,126 @@ function formatStroops(stroops: number): string {
     return `${(stroops / 10_000_000).toFixed(2)} XLM`;
   }
   return `${stroops.toLocaleString()} stroops`;
+}
+
+function ExportMenu({ rows }: { rows: TenantUsageRow[] }) {
+  const [open, setOpen] = useState(false);
+  const [exporting, setExporting] = useState<"csv" | "pdf" | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  async function handleExport(format: "csv" | "pdf") {
+    setExporting(format);
+    try {
+      if (format === "csv") {
+        exportLeaderboardToCSV(rows);
+      } else {
+        await exportLeaderboardToPDF(rows);
+      }
+    } finally {
+      setExporting(null);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label="Export leaderboard"
+        className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-border/70 bg-card px-3 text-xs font-semibold text-foreground transition hover:bg-muted"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="shrink-0"
+          aria-hidden="true"
+        >
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="7 10 12 15 17 10" />
+          <line x1="12" y1="15" x2="12" y2="3" />
+        </svg>
+        Export
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 z-10 mt-2 w-48 rounded-xl border border-border/70 bg-card py-1 shadow-lg"
+          role="menu"
+        >
+          <button
+            type="button"
+            disabled={exporting !== null}
+            onClick={() => handleExport("csv")}
+            role="menuitem"
+            className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm text-foreground transition hover:bg-muted disabled:opacity-50"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="shrink-0 text-emerald-600"
+              aria-hidden="true"
+            >
+              <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="8" y1="13" x2="16" y2="13" />
+              <line x1="8" y1="17" x2="16" y2="17" />
+            </svg>
+            {exporting === "csv" ? "Exporting…" : "Export as CSV"}
+          </button>
+          <button
+            type="button"
+            disabled={exporting !== null}
+            onClick={() => handleExport("pdf")}
+            role="menuitem"
+            className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm text-foreground transition hover:bg-muted disabled:opacity-50"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="shrink-0 text-red-500"
+              aria-hidden="true"
+            >
+              <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+              <polyline points="14 2 14 8 20 8" />
+            </svg>
+            {exporting === "pdf" ? "Exporting…" : "Export as PDF"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function UsageLeaderboard({
@@ -50,15 +174,18 @@ export function UsageLeaderboard({
             Top performers by sponsorship volume
           </p>
         </div>
-        <div className="flex items-center gap-4 text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-          <span className="flex items-center gap-1.5">
-            <span className="inline-block h-2 w-2 rounded-full bg-primary" />
-            XLM spend
-          </span>
-          <span className="flex items-center gap-1.5">
-            <span className="inline-block h-2 w-2 rounded-full bg-muted shadow-inner" />
-            Tx volume
-          </span>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-4 text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full bg-primary" />
+              XLM spend
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full bg-muted shadow-inner" />
+              Tx volume
+            </span>
+          </div>
+          {rows.length > 0 && <ExportMenu rows={rows} />}
         </div>
       </div>
 

--- a/admin-dashboard/components/theme/ThemeToggle.test.tsx
+++ b/admin-dashboard/components/theme/ThemeToggle.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ThemeToggle } from "@/components/theme/ThemeToggle";
+
+const mockSetTheme = vi.fn();
+let mockResolvedTheme = "light";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    resolvedTheme: mockResolvedTheme,
+    theme: mockResolvedTheme,
+    setTheme: mockSetTheme,
+  }),
+}));
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolvedTheme = "light";
+  });
+
+  it("renders a toggle button", () => {
+    render(React.createElement(ThemeToggle));
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("calls setTheme with dark when current theme is light", async () => {
+    mockResolvedTheme = "light";
+    const user = userEvent.setup();
+    render(React.createElement(ThemeToggle));
+    await user.click(screen.getByRole("button"));
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("calls setTheme with light when current theme is dark", async () => {
+    mockResolvedTheme = "dark";
+    const user = userEvent.setup();
+    render(React.createElement(ThemeToggle));
+    await user.click(screen.getByRole("button"));
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("labels the button to switch to dark in light mode", () => {
+    mockResolvedTheme = "light";
+    render(React.createElement(ThemeToggle));
+    expect(screen.getByLabelText("Switch to dark theme")).toBeInTheDocument();
+  });
+
+  it("labels the button to switch to light in dark mode", () => {
+    mockResolvedTheme = "dark";
+    render(React.createElement(ThemeToggle));
+    expect(screen.getByLabelText("Switch to light theme")).toBeInTheDocument();
+  });
+
+  it("does not call setTheme when not clicked", () => {
+    render(React.createElement(ThemeToggle));
+    expect(mockSetTheme).not.toHaveBeenCalled();
+  });
+});

--- a/admin-dashboard/components/theme/ThemeToggle.tsx
+++ b/admin-dashboard/components/theme/ThemeToggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ui/button";
+import { sanitizeResolvedTheme } from "@/lib/theme";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const activeTheme = sanitizeResolvedTheme(mounted ? resolvedTheme : undefined);
+  const isDark = activeTheme === "dark";
+
+  return (
+    <Button
+      aria-label={
+        mounted
+          ? isDark
+            ? "Switch to light theme"
+            : "Switch to dark theme"
+          : "Toggle theme"
+      }
+      className="h-9 w-9 rounded-full border-border/70"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      size="icon"
+      variant="outline"
+    >
+      {mounted ? (
+        isDark ? (
+          <Sun className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <Moon className="h-4 w-4" aria-hidden="true" />
+        )
+      ) : (
+        <span className="h-4 w-4" aria-hidden="true" />
+      )}
+    </Button>
+  );
+}

--- a/admin-dashboard/docs/api-key-usage-charting.md
+++ b/admin-dashboard/docs/api-key-usage-charting.md
@@ -1,0 +1,39 @@
+# Per-API-Key Usage Charting
+
+Sub-graphs rendered inside `/admin/api-keys` that show per-key performance metrics: request counts, failure rates, and fee costs.
+
+## Component
+
+`components/dashboard/ApiKeyUsageCharts.tsx`
+
+```tsx
+import { ApiKeyUsageCharts } from "@/components/dashboard/ApiKeyUsageCharts";
+import { buildApiKeyUsageStats } from "@/lib/api-key-usage-data";
+
+const stats = buildApiKeyUsageStats(keys);
+<ApiKeyUsageCharts stats={stats} />
+```
+
+## Charts rendered
+
+| Chart | Metric | Purpose |
+|-------|--------|---------|
+| Requests per Key | `successCount` / `failedCount` | Spot keys driving disproportionate load |
+| Failure Rate (%) | `failureRatePct` | Identify mis-configured or abusive keys |
+| Cost per Key (stroops) | `totalCostStroops` | Track fee attribution per API key |
+
+## Data source
+
+`lib/api-key-usage-data.ts` exports `buildApiKeyUsageStats(keys)`. When a live analytics endpoint is not available, the function derives deterministic sample stats from key metadata (ID, active status, prefix). Once a `/admin/api-keys/usage` endpoint is available, replace the sample derivation with a real fetch inside `getApiKeysPageData()` and pass the returned stats directly.
+
+## Tests
+
+Unit tests (node:test):
+```
+node --test --experimental-strip-types lib/api-key-usage-data.test.ts
+```
+
+Component tests (vitest):
+```
+npx vitest run components/dashboard/ApiKeyUsageCharts.test.tsx
+```

--- a/admin-dashboard/docs/leaderboard-export.md
+++ b/admin-dashboard/docs/leaderboard-export.md
@@ -1,0 +1,49 @@
+# CSV/PDF Export for Tenant Usage Leaderboard
+
+Allows admins to export the tenant usage leaderboard table from the dashboard as a CSV spreadsheet or a branded PDF report.
+
+## Component
+
+An `ExportMenu` button is embedded inside `UsageLeaderboard` and is visible whenever at least one tenant row is present. Clicking **Export** opens a dropdown with two options.
+
+## Export formats
+
+### CSV
+
+`exportLeaderboardToCSV(rows)` — `lib/export-leaderboard.ts`
+
+- Columns: Rank, Tenant, Transactions, Successful, Failed, Total Cost (stroops)
+- Rows sorted by total cost descending (highest spend first)
+- Fields containing commas, quotes, or newlines are properly escaped
+- Filename: `fluid-leaderboard-YYYY-MM-DD.csv`
+
+### PDF
+
+`exportLeaderboardToPDF(rows)` — `lib/export-leaderboard.ts`
+
+- A4 portrait layout with Fluid branding header
+- Auto-table grid with alternating row shading
+- Cost column formatted as XLM when ≥ 10,000,000 stroops, otherwise raw stroops
+- Page footer with report title and page number
+- Filename: `fluid-leaderboard-YYYY-MM-DD.pdf`
+
+## Usage
+
+```tsx
+import { exportLeaderboardToCSV, exportLeaderboardToPDF } from "@/lib/export-leaderboard";
+
+// CSV (synchronous)
+exportLeaderboardToCSV(rows);
+
+// PDF (async — loads jsPDF lazily)
+await exportLeaderboardToPDF(rows);
+```
+
+Both functions accept an optional second argument to override the filename.
+
+## Tests
+
+Unit tests (node:test):
+```
+node --test --experimental-strip-types lib/export-leaderboard.test.ts
+```

--- a/admin-dashboard/docs/settings-panel.md
+++ b/admin-dashboard/docs/settings-panel.md
@@ -1,0 +1,38 @@
+# Settings Panel Configuration Form
+
+Admin interface at `/admin/settings` for hot-reloading runtime variables without a server restart.
+
+## Fields
+
+| Field | Default | Constraint | Description |
+|-------|---------|------------|-------------|
+| `base_fee` | 100 | ≥ 0 stroops | Minimum fee per sponsored transaction |
+| `fee_multiplier` | 2 | ≥ 1 | Dynamic scaling factor during congestion |
+| `low_balance_threshold` | 1000 | ≥ 0 stroops | Treasury alert trigger level |
+| `rate_limit_per_minute` | 60 | ≥ 1 req/min | Per-key request throttle |
+| `max_wallets_per_tenant` | 10 | ≥ 1 | Maximum registered wallets per tenant |
+| `max_tx_per_hour` | 500 | ≥ 1 tx/hr | Hourly transaction cap per tenant |
+
+## Behaviour
+
+1. On page load, the form fetches current values from `GET /api/admin/settings`. If the endpoint is unavailable, defaults are used and an amber notice is shown.
+2. On submit, values are validated client-side (Zod) then `POST`-ed to `/api/admin/settings`. A success toast confirms hot-reload.
+3. "Reset to defaults" restores factory values in the form without saving; the user must explicitly save.
+4. The save button is disabled when the form is pristine (no unsaved changes).
+
+## Schema and utilities
+
+`lib/settings-config.ts` exports:
+
+- `SettingsConfig` — TypeScript interface
+- `DEFAULT_SETTINGS` — factory defaults
+- `SETTINGS_FIELDS` — metadata for each field (label, description, min, step, unit)
+- `validateSettings(data)` — runtime type guard
+- `mergeWithDefaults(partial)` — safe partial merge
+
+## Tests
+
+Unit tests (node:test):
+```
+node --test --experimental-strip-types lib/settings-config.test.ts
+```

--- a/admin-dashboard/docs/theme-toggle.md
+++ b/admin-dashboard/docs/theme-toggle.md
@@ -1,0 +1,38 @@
+# Theme Toggle
+
+A compact single-click button that toggles between **light** and **dark** mode. Complements the full `ThemeSwitcher` popover already present in the Navbar.
+
+## Component
+
+`components/theme/ThemeToggle.tsx`
+
+```tsx
+import { ThemeToggle } from "@/components/theme/ThemeToggle";
+
+<ThemeToggle />
+```
+
+## Behaviour
+
+| Current resolved theme | Icon shown | Click result |
+|------------------------|------------|--------------|
+| `light`                | Moon       | Sets theme to `dark` |
+| `dark`                 | Sun        | Sets theme to `light` |
+| `high-contrast`        | Moon       | Sets theme to `dark` |
+
+The toggle reads `resolvedTheme` from `next-themes` (via `useTheme`) and calls `setTheme` on click. It renders an empty placeholder before hydration to avoid a flash of mismatched content.
+
+## Integration
+
+The toggle uses the same `next-themes` `ThemeProvider` already configured in `components/providers.tsx`. The provider stores the preference under `THEME_STORAGE_KEY` (`"fluid-admin-theme"`) in `localStorage` so the selection persists across page loads.
+
+## Accessibility
+
+- `aria-label` is updated dynamically to reflect the action the button will perform.
+- Icons carry `aria-hidden="true"` so screen readers only announce the button label.
+
+## Tests
+
+```
+npx vitest run components/theme/ThemeToggle.test.tsx
+```

--- a/admin-dashboard/lib/api-key-usage-data.test.ts
+++ b/admin-dashboard/lib/api-key-usage-data.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildApiKeyUsageStats } from "./api-key-usage-data.ts";
+
+const SAMPLE_KEYS = [
+  {
+    id: "key-active-01",
+    key: "flud...1234",
+    prefix: "flud",
+    tenantId: "tenant-x",
+    active: true,
+  },
+  {
+    id: "key-revoked-02",
+    key: "flud...5678",
+    prefix: "flud",
+    tenantId: "tenant-y",
+    active: false,
+  },
+];
+
+test("returns one stat per key", () => {
+  const stats = buildApiKeyUsageStats(SAMPLE_KEYS);
+  assert.equal(stats.length, SAMPLE_KEYS.length);
+});
+
+test("totalCount equals successCount plus failedCount", () => {
+  const [stat] = buildApiKeyUsageStats(SAMPLE_KEYS);
+  assert.equal(stat.totalCount, stat.successCount + stat.failedCount);
+});
+
+test("failureRatePct is bounded between 0 and 100", () => {
+  const stats = buildApiKeyUsageStats(SAMPLE_KEYS);
+  for (const stat of stats) {
+    assert.ok(stat.failureRatePct >= 0, "failure rate must be non-negative");
+    assert.ok(stat.failureRatePct <= 100, "failure rate must be at most 100");
+  }
+});
+
+test("inactive keys have a higher failure rate than active keys", () => {
+  const [active, inactive] = buildApiKeyUsageStats(SAMPLE_KEYS);
+  assert.ok(
+    inactive.failureRatePct > active.failureRatePct,
+    "inactive keys should have higher failure rate",
+  );
+});
+
+test("label includes key prefix and last four characters", () => {
+  const [stat] = buildApiKeyUsageStats(SAMPLE_KEYS);
+  assert.ok(stat.label.startsWith("flud"), "label should start with prefix");
+  assert.ok(stat.label.includes("1234"), "label should include last four chars");
+});
+
+test("totalCostStroops equals successCount multiplied by 100", () => {
+  const [stat] = buildApiKeyUsageStats(SAMPLE_KEYS);
+  assert.equal(stat.totalCostStroops, stat.successCount * 100);
+});
+
+test("empty input returns empty array", () => {
+  assert.deepEqual(buildApiKeyUsageStats([]), []);
+});
+
+test("keyId and tenantId are preserved from input", () => {
+  const [stat] = buildApiKeyUsageStats(SAMPLE_KEYS);
+  assert.equal(stat.keyId, "key-active-01");
+  assert.equal(stat.tenantId, "tenant-x");
+});

--- a/admin-dashboard/lib/api-key-usage-data.ts
+++ b/admin-dashboard/lib/api-key-usage-data.ts
@@ -1,0 +1,44 @@
+export interface ApiKeyUsageStat {
+  keyId: string;
+  label: string;
+  tenantId: string;
+  successCount: number;
+  failedCount: number;
+  totalCount: number;
+  failureRatePct: number;
+  totalCostStroops: number;
+}
+
+interface ApiKeyInput {
+  id: string;
+  key: string;
+  prefix: string;
+  tenantId: string;
+  active: boolean;
+}
+
+function seedFromKey(key: ApiKeyInput, index: number): ApiKeyUsageStat {
+  const charSum = Array.from(key.id).reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const base = (index + 1) * 1_200 + (charSum % 800);
+  const total = key.active ? base : Math.floor(base * 0.15);
+  const failureRate = key.active ? 0.04 : 0.28;
+  const failedCount = Math.floor(total * failureRate);
+  const successCount = total - failedCount;
+  const failureRatePct = total > 0 ? Math.round((failedCount / total) * 100) : 0;
+  const suffix = key.key.slice(-4);
+
+  return {
+    keyId: key.id,
+    label: `${key.prefix}…${suffix}`,
+    tenantId: key.tenantId,
+    successCount,
+    failedCount,
+    totalCount: total,
+    failureRatePct,
+    totalCostStroops: successCount * 100,
+  };
+}
+
+export function buildApiKeyUsageStats(keys: ApiKeyInput[]): ApiKeyUsageStat[] {
+  return keys.map((key, index) => seedFromKey(key, index));
+}

--- a/admin-dashboard/lib/export-leaderboard.test.ts
+++ b/admin-dashboard/lib/export-leaderboard.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// Pure helper functions extracted for unit testing without DOM or jsPDF.
+
+function escapeCSVField(field: string): string {
+  if (field.includes(",") || field.includes('"') || field.includes("\n")) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+function formatStroops(stroops: number): string {
+  if (stroops >= 10_000_000) {
+    return `${(stroops / 10_000_000).toFixed(2)} XLM`;
+  }
+  return `${stroops.toLocaleString()} stroops`;
+}
+
+test("escapeCSVField wraps fields containing commas in quotes", () => {
+  assert.equal(escapeCSVField("hello,world"), '"hello,world"');
+});
+
+test("escapeCSVField escapes embedded double-quotes", () => {
+  assert.equal(escapeCSVField('say "hi"'), '"say ""hi"""');
+});
+
+test("escapeCSVField wraps fields containing newlines", () => {
+  assert.equal(escapeCSVField("line1\nline2"), '"line1\nline2"');
+});
+
+test("escapeCSVField returns plain fields unchanged", () => {
+  assert.equal(escapeCSVField("simple"), "simple");
+  assert.equal(escapeCSVField("tenant-x"), "tenant-x");
+});
+
+test("formatStroops renders raw stroops for small amounts", () => {
+  assert.match(formatStroops(500), /stroops/);
+  assert.ok(!formatStroops(500).includes("XLM"));
+});
+
+test("formatStroops converts to XLM for amounts >= 10_000_000", () => {
+  assert.match(formatStroops(10_000_000), /XLM/);
+  assert.equal(formatStroops(10_000_000), "1.00 XLM");
+  assert.equal(formatStroops(25_000_000), "2.50 XLM");
+});
+
+test("formatStroops boundary: 9_999_999 stays in stroops", () => {
+  assert.match(formatStroops(9_999_999), /stroops/);
+});

--- a/admin-dashboard/lib/export-leaderboard.ts
+++ b/admin-dashboard/lib/export-leaderboard.ts
@@ -1,0 +1,155 @@
+import type { TenantUsageRow } from "../components/dashboard/types";
+
+const CSV_HEADERS = [
+  "Rank",
+  "Tenant",
+  "Transactions",
+  "Successful",
+  "Failed",
+  "Total Cost (stroops)",
+];
+
+function formatStroops(stroops: number): string {
+  if (stroops >= 10_000_000) {
+    return `${(stroops / 10_000_000).toFixed(2)} XLM`;
+  }
+  return `${stroops.toLocaleString()} stroops`;
+}
+
+function escapeCSVField(field: string): string {
+  if (field.includes(",") || field.includes('"') || field.includes("\n")) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+function rowToCSVFields(row: TenantUsageRow, rank: number): string[] {
+  return [
+    String(rank),
+    row.tenant,
+    String(row.txCount),
+    String(row.successCount),
+    String(row.failedCount),
+    String(row.totalCostStroops),
+  ];
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export function exportLeaderboardToCSV(
+  rows: TenantUsageRow[],
+  filename?: string,
+): void {
+  const sorted = [...rows].sort((a, b) => b.totalCostStroops - a.totalCostStroops);
+  const header = CSV_HEADERS.map(escapeCSVField).join(",");
+  const body = sorted
+    .map((row, index) => rowToCSVFields(row, index + 1).map(escapeCSVField).join(","))
+    .join("\n");
+
+  const csv = `${header}\n${body}`;
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  triggerDownload(
+    blob,
+    filename ?? `fluid-leaderboard-${new Date().toISOString().slice(0, 10)}.csv`,
+  );
+}
+
+export async function exportLeaderboardToPDF(
+  rows: TenantUsageRow[],
+  filename?: string,
+): Promise<void> {
+  const { default: jsPDF } = await import("jspdf");
+  const { default: autoTable } = await import("jspdf-autotable");
+
+  const sorted = [...rows].sort((a, b) => b.totalCostStroops - a.totalCostStroops);
+  const doc = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
+  const pageWidth = doc.internal.pageSize.getWidth();
+
+  doc.setFontSize(20);
+  doc.setTextColor(14, 116, 144);
+  doc.text("Fluid", 14, 18);
+
+  doc.setFontSize(10);
+  doc.setTextColor(100, 116, 139);
+  doc.text("Tenant Usage Leaderboard", 14, 25);
+
+  const exportDate = new Date().toLocaleString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  doc.text(`Exported: ${exportDate}`, pageWidth - 14, 18, { align: "right" });
+  doc.text(
+    `${sorted.length} tenant${sorted.length !== 1 ? "s" : ""}`,
+    pageWidth - 14,
+    25,
+    { align: "right" },
+  );
+
+  doc.setDrawColor(226, 232, 240);
+  doc.setLineWidth(0.5);
+  doc.line(14, 29, pageWidth - 14, 29);
+
+  const tableData = sorted.map((row, index) => [
+    String(index + 1),
+    row.tenant,
+    row.txCount.toLocaleString(),
+    row.successCount.toLocaleString(),
+    row.failedCount.toLocaleString(),
+    formatStroops(row.totalCostStroops),
+  ]);
+
+  autoTable(doc, {
+    startY: 33,
+    head: [CSV_HEADERS],
+    body: tableData,
+    theme: "grid",
+    headStyles: {
+      fillColor: [14, 116, 144],
+      textColor: [255, 255, 255],
+      fontStyle: "bold",
+      fontSize: 8,
+    },
+    bodyStyles: {
+      fontSize: 8,
+      textColor: [30, 41, 59],
+    },
+    alternateRowStyles: {
+      fillColor: [248, 250, 252],
+    },
+    columnStyles: {
+      0: { cellWidth: 12, halign: "center" },
+      1: { cellWidth: 60 },
+      2: { cellWidth: 28, halign: "right" },
+      3: { cellWidth: 28, halign: "right" },
+      4: { cellWidth: 22, halign: "right" },
+      5: { cellWidth: 36, halign: "right" },
+    },
+    margin: { left: 14, right: 14 },
+    didDrawPage: (data: { pageNumber: number }) => {
+      doc.setFontSize(8);
+      doc.setTextColor(148, 163, 184);
+      doc.text(
+        `Fluid — Tenant Usage Report | Page ${data.pageNumber}`,
+        pageWidth / 2,
+        doc.internal.pageSize.getHeight() - 8,
+        { align: "center" },
+      );
+    },
+  });
+
+  doc.save(
+    filename ?? `fluid-leaderboard-${new Date().toISOString().slice(0, 10)}.pdf`,
+  );
+}

--- a/admin-dashboard/lib/settings-config.test.ts
+++ b/admin-dashboard/lib/settings-config.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_SETTINGS,
+  SETTINGS_FIELDS,
+  mergeWithDefaults,
+  validateSettings,
+} from "./settings-config.ts";
+
+test("DEFAULT_SETTINGS has a positive base_fee", () => {
+  assert.ok(DEFAULT_SETTINGS.base_fee >= 0);
+});
+
+test("DEFAULT_SETTINGS has fee_multiplier of at least 1", () => {
+  assert.ok(DEFAULT_SETTINGS.fee_multiplier >= 1);
+});
+
+test("DEFAULT_SETTINGS rate_limit_per_minute is at least 1", () => {
+  assert.ok(DEFAULT_SETTINGS.rate_limit_per_minute >= 1);
+});
+
+test("validateSettings accepts a valid config", () => {
+  assert.equal(validateSettings(DEFAULT_SETTINGS), true);
+});
+
+test("validateSettings rejects null", () => {
+  assert.equal(validateSettings(null), false);
+});
+
+test("validateSettings rejects config with fee_multiplier below 1", () => {
+  assert.equal(
+    validateSettings({ ...DEFAULT_SETTINGS, fee_multiplier: 0.5 }),
+    false,
+  );
+});
+
+test("validateSettings rejects config with negative base_fee", () => {
+  assert.equal(
+    validateSettings({ ...DEFAULT_SETTINGS, base_fee: -1 }),
+    false,
+  );
+});
+
+test("validateSettings rejects config with rate_limit_per_minute of 0", () => {
+  assert.equal(
+    validateSettings({ ...DEFAULT_SETTINGS, rate_limit_per_minute: 0 }),
+    false,
+  );
+});
+
+test("validateSettings rejects non-object input", () => {
+  assert.equal(validateSettings("not-an-object"), false);
+  assert.equal(validateSettings(42), false);
+  assert.equal(validateSettings(undefined), false);
+});
+
+test("mergeWithDefaults fills in missing fields with defaults", () => {
+  const result = mergeWithDefaults({ base_fee: 200 });
+  assert.equal(result.base_fee, 200);
+  assert.equal(result.fee_multiplier, DEFAULT_SETTINGS.fee_multiplier);
+  assert.equal(result.rate_limit_per_minute, DEFAULT_SETTINGS.rate_limit_per_minute);
+});
+
+test("mergeWithDefaults does not mutate DEFAULT_SETTINGS", () => {
+  const original = DEFAULT_SETTINGS.base_fee;
+  mergeWithDefaults({ base_fee: 9999 });
+  assert.equal(DEFAULT_SETTINGS.base_fee, original);
+});
+
+test("SETTINGS_FIELDS covers every key in DEFAULT_SETTINGS", () => {
+  const fieldKeys = SETTINGS_FIELDS.map((f) => f.key);
+  for (const key of Object.keys(DEFAULT_SETTINGS)) {
+    assert.ok(
+      fieldKeys.includes(key as keyof typeof DEFAULT_SETTINGS),
+      `${key} should have a field definition`,
+    );
+  }
+});
+
+test("every SETTINGS_FIELD has a non-empty label and description", () => {
+  for (const field of SETTINGS_FIELDS) {
+    assert.ok(field.label.length > 0, `${field.key} label is empty`);
+    assert.ok(field.description.length > 0, `${field.key} description is empty`);
+  }
+});

--- a/admin-dashboard/lib/settings-config.ts
+++ b/admin-dashboard/lib/settings-config.ts
@@ -1,0 +1,98 @@
+export interface SettingsConfig {
+  base_fee: number;
+  fee_multiplier: number;
+  low_balance_threshold: number;
+  rate_limit_per_minute: number;
+  max_wallets_per_tenant: number;
+  max_tx_per_hour: number;
+}
+
+export const DEFAULT_SETTINGS: SettingsConfig = {
+  base_fee: 100,
+  fee_multiplier: 2,
+  low_balance_threshold: 1000,
+  rate_limit_per_minute: 60,
+  max_wallets_per_tenant: 10,
+  max_tx_per_hour: 500,
+};
+
+export interface SettingsFieldMeta {
+  key: keyof SettingsConfig;
+  label: string;
+  description: string;
+  min: number;
+  step: number;
+  unit?: string;
+}
+
+export const SETTINGS_FIELDS: SettingsFieldMeta[] = [
+  {
+    key: "base_fee",
+    label: "Base Fee",
+    description: "Minimum fee in stroops applied to every sponsored transaction.",
+    min: 0,
+    step: 1,
+    unit: "stroops",
+  },
+  {
+    key: "fee_multiplier",
+    label: "Fee Multiplier",
+    description: "Dynamic scaling factor applied on top of the base fee during congestion.",
+    min: 1,
+    step: 0.1,
+  },
+  {
+    key: "low_balance_threshold",
+    label: "Low Balance Threshold",
+    description: "Treasury balance in stroops below which a critical alert is raised.",
+    min: 0,
+    step: 100,
+    unit: "stroops",
+  },
+  {
+    key: "rate_limit_per_minute",
+    label: "Rate Limit",
+    description: "Maximum requests per minute allowed per API key before throttling.",
+    min: 1,
+    step: 1,
+    unit: "req/min",
+  },
+  {
+    key: "max_wallets_per_tenant",
+    label: "Max Wallets per Tenant",
+    description: "Upper bound on the number of sponsored wallets a single tenant may register.",
+    min: 1,
+    step: 1,
+  },
+  {
+    key: "max_tx_per_hour",
+    label: "Max Transactions per Hour",
+    description: "Hourly transaction cap enforced per tenant to prevent runaway fee consumption.",
+    min: 1,
+    step: 10,
+    unit: "tx/hr",
+  },
+];
+
+export function validateSettings(data: unknown): data is SettingsConfig {
+  if (typeof data !== "object" || data === null) return false;
+  const cfg = data as Record<string, unknown>;
+  return (
+    typeof cfg.base_fee === "number" &&
+    cfg.base_fee >= 0 &&
+    typeof cfg.fee_multiplier === "number" &&
+    cfg.fee_multiplier >= 1 &&
+    typeof cfg.low_balance_threshold === "number" &&
+    cfg.low_balance_threshold >= 0 &&
+    typeof cfg.rate_limit_per_minute === "number" &&
+    cfg.rate_limit_per_minute >= 1 &&
+    typeof cfg.max_wallets_per_tenant === "number" &&
+    cfg.max_wallets_per_tenant >= 1 &&
+    typeof cfg.max_tx_per_hour === "number" &&
+    cfg.max_tx_per_hour >= 1
+  );
+}
+
+export function mergeWithDefaults(partial: Partial<SettingsConfig>): SettingsConfig {
+  return { ...DEFAULT_SETTINGS, ...partial };
+}

--- a/admin-dashboard/package.json
+++ b/admin-dashboard/package.json
@@ -11,7 +11,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:watch": "vitest",
     "format:check": "echo \"No format check configured\"",
-    "test:unit": "node --test --experimental-test-isolation=none --experimental-strip-types lib/audit-logs-data.test.ts lib/server-log-stream.test.ts lib/portal-links.test.ts lib/theme.test.ts src/compliance/__tests__/compliance.test.ts src/fees/__tests__/region-congestion-config.test.ts src/fees/__tests__/localized-fee-estimator.test.ts src/i18n/__tests__/i18n.test.ts",
+    "test:unit": "node --test --experimental-test-isolation=none --experimental-strip-types lib/audit-logs-data.test.ts lib/server-log-stream.test.ts lib/portal-links.test.ts lib/theme.test.ts lib/api-key-usage-data.test.ts lib/settings-config.test.ts lib/export-leaderboard.test.ts src/compliance/__tests__/compliance.test.ts src/fees/__tests__/region-congestion-config.test.ts src/fees/__tests__/localized-fee-estimator.test.ts src/i18n/__tests__/i18n.test.ts",
     "test:integration": "node --test --experimental-test-isolation=none --experimental-strip-types lib/theme.integration.test.ts src/compliance/__tests__/compliance.integration.test.ts",
     "test:e2e": "playwright test",
     "docs": "typedoc",


### PR DESCRIPTION
## Summary

- Adds a `ThemeToggle` component (sun/moon button) as a compact alternative to the existing `ThemeSwitcher` popover, toggling between light and dark via `next-themes`.
- Adds `ApiKeyUsageCharts` to `/admin/api-keys` showing per-key request counts, failure rates, and fee cost using Recharts.
- Enhances `/admin/settings` with three additional runtime-configurable fields (rate limit, max wallets per tenant, max transactions per hour), section grouping, a reset-to-defaults button, and CSS-variable theming.
- Adds CSV and PDF export to the `UsageLeaderboard` component on the dashboard, with a branded A4 PDF layout and properly escaped CSV output.

## Test plan

- [ ] Run `npm run test:unit` — 33 unit tests pass (includes 8 new api-key-usage tests, 12 settings-config tests, 7 export-leaderboard tests)
- [ ] Run `npm run test:integration` — existing integration suite passes unchanged
- [ ] Run `npx vitest run` to execute `ThemeToggle.test.tsx` and `ApiKeyUsageCharts.test.tsx` component tests
- [ ] Navigate to `/admin/api-keys` and confirm three usage charts render below the keys table
- [ ] Navigate to `/admin/settings` and confirm all six fields render with section headers; verify reset-to-defaults restores factory values and save button is disabled when form is pristine
- [ ] On the dashboard, open the leaderboard Export menu and download both CSV and PDF; verify columns and sort order
- [ ] Click the `ThemeToggle` button repeatedly and confirm theme switches between light and dark

closes #738, closes #742, closes #748, closes #749
