### PR TITLE
Harden admin sessions, fee-bump errors, and DB adapters

### DIFF
--- a/admin-dashboard/auth.ts
+++ b/admin-dashboard/auth.ts
@@ -2,17 +2,20 @@ import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
 import type { AdminRole } from "./lib/permissions";
+import { getRequestIp } from "./lib/request-ip";
 
 declare module "next-auth" {
   interface User {
     role?: string;
     adminJwt?: string;
+    ipAddress?: string;
   }
   interface Session {
     user: {
       email?: string | null;
       role?: string;
       adminJwt?: string;
+      ipAddress?: string;
     };
   }
 }
@@ -21,6 +24,7 @@ declare module "next-auth/jwt" {
   interface JWT {
     role?: string;
     adminJwt?: string;
+    ipAddress?: string;
     iat?: number;
     exp?: number;
   }
@@ -36,7 +40,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         email: { label: "Email", type: "email" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, request) {
         if (!credentials?.email || !credentials?.password) return null;
 
         const email = credentials.email as string;
@@ -48,6 +52,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
         if (serverUrl && adminToken) {
           try {
+            const clientIp = getRequestIp(request);
             const resp = await fetch(`${serverUrl}/admin/auth/login`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -60,6 +65,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
                 email,
                 role: data.role as AdminRole,
                 adminJwt: data.token,
+                ipAddress: clientIp ?? undefined,
               };
             }
           } catch {
@@ -82,7 +88,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         const passwordMatch = await bcrypt.compare(password, adminPasswordHash);
         if (!passwordMatch) return null;
 
-        return { id: "env-admin", email: adminEmail, role: "SUPER_ADMIN" };
+        return {
+          id: "env-admin",
+          email: adminEmail,
+          role: "SUPER_ADMIN",
+          ipAddress: getRequestIp(request) ?? undefined,
+        };
       },
     }),
   ],
@@ -95,6 +106,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         // Initial sign-in
         token.role = user.role;
         token.adminJwt = user.adminJwt;
+        token.ipAddress = user.ipAddress;
         token.iat = now;
         token.exp = now + JWT_EXPIRATION;
       } else if (token.iat && token.exp) {
@@ -146,6 +158,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       if (session.user) {
         session.user.role = token.role as string;
         session.user.adminJwt = token.adminJwt as string | undefined;
+        session.user.ipAddress = token.ipAddress as string | undefined;
       }
       return session;
     },

--- a/admin-dashboard/lib/request-ip.ts
+++ b/admin-dashboard/lib/request-ip.ts
@@ -1,0 +1,39 @@
+type RequestLike = {
+  headers?: Headers;
+  ip?: string | null;
+};
+
+function firstHeaderValue(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const [first] = value.split(",");
+  const trimmed = first?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function getRequestIp(request?: RequestLike | null): string | null {
+  if (!request) {
+    return null;
+  }
+
+  const headers = request.headers;
+  const forwardedFor = firstHeaderValue(headers?.get("x-forwarded-for"));
+  if (forwardedFor) {
+    return forwardedFor;
+  }
+
+  const realIp = firstHeaderValue(headers?.get("x-real-ip"));
+  if (realIp) {
+    return realIp;
+  }
+
+  const connectingIp = firstHeaderValue(headers?.get("cf-connecting-ip"));
+  if (connectingIp) {
+    return connectingIp;
+  }
+
+  const directIp = request.ip?.trim();
+  return directIp ? directIp : null;
+}

--- a/admin-dashboard/middleware.ts
+++ b/admin-dashboard/middleware.ts
@@ -1,10 +1,42 @@
 import { auth } from "@/auth";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { getRequestIp } from "./lib/request-ip";
+
+const SESSION_COOKIE_PREFIXES = [
+  "authjs.session-token",
+  "__Secure-authjs.session-token",
+  "next-auth.session-token",
+  "__Secure-next-auth.session-token",
+];
+
+function clearSessionCookies(response: NextResponse, request: NextRequest): void {
+  for (const cookie of request.cookies.getAll()) {
+    if (
+      SESSION_COOKIE_PREFIXES.some((prefix) => cookie.name.startsWith(prefix))
+    ) {
+      response.cookies.set(cookie.name, "", {
+        expires: new Date(0),
+        httpOnly: true,
+        path: "/",
+        sameSite: "lax",
+        secure: request.nextUrl.protocol === "https:",
+      });
+    }
+  }
+}
 
 export const middlewareCallback = (req: NextRequest & { auth: any }) => {
   const { pathname } = req.nextUrl;
   const session = req.auth;
+  const requestIp = getRequestIp(req);
+
+  if (session?.user?.ipAddress && requestIp && session.user.ipAddress !== requestIp) {
+    const loginUrl = new URL("/login", req.url);
+    const response = NextResponse.redirect(loginUrl);
+    clearSessionCookies(response, req);
+    return response;
+  }
 
   // Force redirect to HTTPS in production
   if (process.env.NODE_ENV === "production") {

--- a/admin-dashboard/types/next-auth.d.ts
+++ b/admin-dashboard/types/next-auth.d.ts
@@ -6,6 +6,7 @@ declare module "next-auth" {
       id: string;
       email: string;
       role: string;
+      ipAddress?: string;
     };
   }
 
@@ -13,11 +14,13 @@ declare module "next-auth" {
     id: string;
     email: string;
     role: string;
+    ipAddress?: string;
   }
 }
 
 declare module "next-auth/jwt" {
   interface JWT {
     role: string;
+    ipAddress?: string;
   }
 }

--- a/server/docs/connection-pool-fine-tuning.md
+++ b/server/docs/connection-pool-fine-tuning.md
@@ -12,7 +12,7 @@ That matches the exact problem PgBouncer solves at the Postgres layer — pool *
 
 ## 2. Non-goals
 
-- **Running a separate PgBouncer process.** Fluid's server uses Prisma over the `better-sqlite3` adapter (single-writer storage). A literal Postgres proxy is not applicable. We implement the *pattern* in-process.
+- **Running a separate PgBouncer process.** Fluid's server now selects the Prisma driver adapter from the configured connection URL, so PostgreSQL deployments can use the pg adapter while local file-based tooling still uses SQLite. We implement the *pattern* in-process.
 - **Replacing Prisma.** The pool is layered *on top of* the existing `prisma` singleton. No model changes.
 
 ## 3. Design
@@ -59,7 +59,7 @@ Snapshot for metrics:
 
 ### 3.2 `createPooledDatabase` — integration with the shared Prisma client
 
-`server/src/db/pooledDatabase.ts` — wraps the existing `prisma` singleton in a pool whose "connections" are lease tokens. Since better-sqlite3 is single-writer, we don't open multiple Prisma clients; the pool acts as a bounded FIFO queue over the one we already have. Every fee-bump request that opts in goes through `db.withConnection(client => ...)`, inheriting all the tuning knobs above.
+`server/src/db/pooledDatabase.ts` — wraps the existing `prisma` singleton in a pool whose "connections" are lease tokens. The pool acts as a bounded FIFO queue over the shared Prisma client, regardless of whether that client is backed by PostgreSQL or the local SQLite fallback. Every fee-bump request that opts in goes through `db.withConnection(client => ...)`, inheriting all the tuning knobs above.
 
 Importantly, the pool's `destroy` is a no-op for this wrapper — destroying a *lease* does not disconnect the shared client. The `validate` hook defaults to a `SELECT 1` probe so unhealthy states surface immediately on acquire.
 

--- a/server/docs/security-txt-verification.md
+++ b/server/docs/security-txt-verification.md
@@ -44,7 +44,7 @@ All files       |     100 |    89.83 |     100 |     100 |
 
 ## Endpoint verification (for required screenshots)
 
-Note: the main server imports the Prisma SQLite adapter (`@prisma/adapter-better-sqlite3`) at startup via `src/utils/db.ts`, which may require native build tooling on some Windows setups (Python + C++ build tools) depending on your Node version.
+Note: the main server now picks the Prisma adapter from `DATABASE_URL` at startup via `src/utils/db.ts`, so PostgreSQL deployments use the pg adapter while file-based local fallbacks still use SQLite. Depending on your Node version and deployment target, this may require native build tooling on some Windows setups.
 
 To capture functional screenshots, run the server and hit the endpoints:
 

--- a/server/package.json
+++ b/server/package.json
@@ -56,6 +56,7 @@
     "@grpc/proto-loader": "^0.8.0",
     "@libsql/client": "^0.17.2",
     "@prisma/adapter-better-sqlite3": "^7.5.0",
+    "@prisma/adapter-pg": "^7.5.0",
     "@prisma/adapter-libsql": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "@prisma/config": "^7.6.0",

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,11 +1,11 @@
 import "dotenv/config";
 import { createLogger, serializeError } from "../src/utils/logger";
-import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { PrismaClient } from "@prisma/client";
 import { randomBytes, createHash } from "crypto";
+import { createPrismaAdapter } from "../src/utils/prismaAdapter";
 
 const dbUrl = process.env["DATABASE_URL"] ?? "file:./dev.db";
-const adapter = new PrismaBetterSqlite3({ url: dbUrl });
+const adapter = createPrismaAdapter(dbUrl);
 const prisma = new PrismaClient({ adapter });
 const logger = createLogger({ component: "prisma_seed" });
 

--- a/server/src/db/SECURITY_AUDIT.md
+++ b/server/src/db/SECURITY_AUDIT.md
@@ -9,7 +9,7 @@ exposed to SQL injection via dynamic string concatenation.
 
 ## 1. Method
 
-The codebase uses Prisma with the `better-sqlite3` adapter (`src/utils/db.ts`).
+The codebase uses Prisma with a driver adapter selected from the configured connection URL (`src/utils/db.ts`).
 Three families of query API are in use:
 
 | API | Value binding | Identifier binding |

--- a/server/src/handlers/feeBump.ts
+++ b/server/src/handlers/feeBump.ts
@@ -86,7 +86,8 @@ function parseInnerTransaction(xdr: string, config: Config): Transaction {
       config.networkPassphrase,
     ) as Transaction;
   } catch (error: any) {
-    throw new AppError(`Invalid XDR: ${error.message}`, 400, "INVALID_XDR");
+    console.error("Failed to parse fee-bump XDR", error);
+    throw new AppError("Invalid XDR", 400, "INVALID_XDR");
   }
 
   if (
@@ -252,11 +253,7 @@ async function executePreparedFeeBump(
           },
         });
 
-        throw new AppError(
-          `Transaction submission failed: ${error.message}`,
-          500,
-          "SUBMISSION_FAILED",
-        );
+        throw new AppError("Transaction submission failed", 500, "SUBMISSION_FAILED");
       }
     }
 
@@ -345,7 +342,7 @@ export async function feeBumpHandler(
     if (!result.success) {
       return next(
         new AppError(
-          `Validation failed: ${JSON.stringify(result.error.format())}`,
+          "Validation failed",
           400,
           "INVALID_XDR",
         ),
@@ -425,7 +422,8 @@ export async function feeBumpHandler(
           config.networkPassphrase,
         ) as any;
       } catch (error: any) {
-        throw new AppError(`Invalid XDR: ${error.message}`, 400, "INVALID_XDR");
+        console.error("Failed to parse fee-bump XDR", error);
+        throw new AppError("Invalid XDR", 400, "INVALID_XDR");
       }
 
       const isSoroban = innerTransaction.operations.some((op: any) =>
@@ -452,8 +450,9 @@ export async function feeBumpHandler(
           );
           params = { ...params, xdr: updatedXdr };
         } catch (error: any) {
+          console.error("Soroban simulation failed", error);
           throw new AppError(
-            `Soroban simulation failed: ${error.message}. The transaction would fail on-chain or out of gas.`,
+            "Soroban simulation failed. The transaction would fail on-chain or out of gas.",
             400,
             "INVALID_XDR",
           );
@@ -623,7 +622,7 @@ export async function feeBumpBatchHandler(
     if (!parsedBody.success) {
       return next(
         new AppError(
-          `Validation failed: ${JSON.stringify(parsedBody.error.format())}`,
+          "Validation failed",
           400,
           "INVALID_XDR",
         ),

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -41,8 +41,6 @@ export function createGlobalErrorHandler(slackNotifier?: SlackNotifierLike) {
     res: Response,
     next: NextFunction,
   ): void {
-    const isProd = process.env.NODE_ENV === "production";
-
     if (err instanceof AppError) {
       notify5xx(slackNotifier, req, err.statusCode, err);
       res.status(err.statusCode).json({
@@ -65,9 +63,8 @@ export function createGlobalErrorHandler(slackNotifier?: SlackNotifierLike) {
     notify5xx(slackNotifier, req, 500, err);
 
     res.status(500).json({
-      error: isProd ? "An unexpected error occurred" : err.message,
+      error: "An unexpected error occurred",
       code: "INTERNAL_ERROR",
-      ...(isProd ? {} : { stack: err.stack }),
     });
   };
 }

--- a/server/src/services/regionRouter.ts
+++ b/server/src/services/regionRouter.ts
@@ -15,8 +15,8 @@
  *   3. file:./dev.db           – local dev default
  */
 
-import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { createLogger } from "../utils/logger";
+import { createPrismaAdapter } from "../utils/prismaAdapter";
 
 const logger = createLogger({ component: "region_router" });
 
@@ -39,7 +39,7 @@ function loadPrismaClient(): PrismaModule["PrismaClient"] {
 
 function buildClient(url: string): PrismaClientLike {
   const PrismaClient = loadPrismaClient();
-  const adapter = new PrismaBetterSqlite3({ url });
+  const adapter = createPrismaAdapter(url);
   return new PrismaClient({
     adapter,
     log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],

--- a/server/src/utils/db.ts
+++ b/server/src/utils/db.ts
@@ -1,5 +1,5 @@
-import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { encryptionExtension } from "./prismaEncryption";
+import { createPrismaAdapter } from "./prismaAdapter";
 
 type PrismaClientLike = {
   [key: string]: any;
@@ -36,7 +36,7 @@ const logLevel =
 // ── Primary client (writes + non-analytic reads) ────────────────────────────
 
 const dbUrl = process.env.DATABASE_URL ?? "file:./dev.db";
-const adapter = new PrismaBetterSqlite3({ url: dbUrl });
+const adapter = createPrismaAdapter(dbUrl);
 
 const basePrisma =
   globalForPrisma.prisma ??
@@ -60,7 +60,7 @@ if (process.env.NODE_ENV !== "production") {
 // Falls back to DATABASE_URL when no replica is configured (development, staging).
 
 const replicaUrl = process.env.DATABASE_REPLICA_URL ?? dbUrl;
-const replicaAdapter = new PrismaBetterSqlite3({ url: replicaUrl });
+const replicaAdapter = createPrismaAdapter(replicaUrl);
 
 const baseReplicaPrisma =
   globalForPrisma.replicaPrisma ??

--- a/server/src/utils/prismaAdapter.ts
+++ b/server/src/utils/prismaAdapter.ts
@@ -1,0 +1,15 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+
+export function createPrismaAdapter(url: string): any {
+  const normalizedUrl = url.trim().toLowerCase();
+
+  if (
+    normalizedUrl.startsWith("postgresql://") ||
+    normalizedUrl.startsWith("postgres://")
+  ) {
+    return new PrismaPg({ connectionString: url });
+  }
+
+  return new PrismaBetterSqlite3({ url });
+}

--- a/server/src/utils/readDb.ts
+++ b/server/src/utils/readDb.ts
@@ -1,4 +1,4 @@
-import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import { createPrismaAdapter } from "./prismaAdapter";
 
 type PrismaClientLike = {
   [key: string]: any;
@@ -39,7 +39,7 @@ const replicaUrl =
   process.env.DATABASE_URL ??
   "file:./dev.db";
 
-const adapter = new PrismaBetterSqlite3({ url: replicaUrl });
+const adapter = createPrismaAdapter(replicaUrl);
 
 export const readPrisma = new PrismaClient({
   adapter,


### PR DESCRIPTION
Bind admin sessions to the originating IP, sanitize fee-bump/server error responses, and route Prisma adapters from the configured connection URL.

Closes #698
Closes #670
Closes #673
Closes #672
