### PR TITLE
fluid-server: dependency scans (#674) and inner tx signer-weight preflight (#686)

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,69 @@
+name: Dependency Vulnerability Audit (fluid-server)
+
+on:
+  pull_request:
+    paths:
+      - "fluid-server/**"
+      - ".github/workflows/dependency-audit.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "fluid-server/**"
+      - ".github/workflows/dependency-audit.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audit:
+    name: ${{ matrix.scanner }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scanner: cargo-audit
+            working-directory: fluid-server
+          - scanner: npm-audit
+            working-directory: fluid-server/wasm-demo
+
+    defaults:
+      run:
+        working-directory: ${{ matrix.working-directory }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: cargo-audit (Rust)
+        if: matrix.scanner == 'cargo-audit'
+        run: |
+          cargo install cargo-audit --locked
+          cargo audit --version
+          cargo audit --json > "${RUNNER_TEMP}/cargo-audit-report.json"
+          cargo audit --deny warnings
+
+      - name: Upload cargo-audit report
+        if: matrix.scanner == 'cargo-audit' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-audit-report
+          path: ${{ runner.temp }}/cargo-audit-report.json
+          if-no-files-found: warn
+
+      - name: npm audit (wasm-demo)
+        if: matrix.scanner == 'npm-audit'
+        run: |
+          npm --version
+          npm ci
+          npm audit --json > "${RUNNER_TEMP}/npm-audit-report.json" || true
+          npm audit --audit-level=high
+
+      - name: Upload npm-audit report
+        if: matrix.scanner == 'npm-audit' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: ${{ runner.temp }}/npm-audit-report.json
+          if-no-files-found: warn

--- a/fluid-server/audit.toml
+++ b/fluid-server/audit.toml
@@ -1,0 +1,5 @@
+# cargo-audit configuration for fluid-server (#674).
+# Document known, reviewed advisories here so CI stays green while tracking debt.
+
+[advisories]
+ignore = []

--- a/fluid-server/docs/inner-transaction-signer-weight-validation.md
+++ b/fluid-server/docs/inner-transaction-signer-weight-validation.md
@@ -1,0 +1,30 @@
+# Inner Transaction Signer Weight Pre-flight Validation (#686)
+
+Before the Rust fee-bump relay wraps a signed inner transaction, it validates that the inner envelope's signature weight meets the source account's `med_threshold` on the Stellar network.
+
+## Flow
+
+1. Decode the submitted inner `TransactionEnvelope::Tx`.
+2. Resolve the classic ed25519 source account id (`G…`).
+3. Fetch `thresholds` and `signers` from Horizon (`GET /accounts/{id}`).
+4. Match each `DecoratedSignature` hint against configured ed25519 signers and sum weights.
+5. Reject with `INSUFFICIENT_SIGNATURE_WEIGHT` when `total_weight < med_threshold`.
+
+## Error codes
+
+| Code | When |
+|------|------|
+| `INSUFFICIENT_SIGNATURE_WEIGHT` | Signatures present but total weight is below `med_threshold`, or no hint matches account signers |
+| `UNSUPPORTED_SOURCE_ACCOUNT` | Muxed / V0 / fee-bump envelopes (not supported for this check) |
+| `ACCOUNT_NOT_FOUND` | Horizon returns 404 for the source account |
+| `HORIZON_LOOKUP_FAILED` | Horizon cluster unavailable or returned a non-retryable error |
+
+## Configuration
+
+Validation runs when at least one Horizon URL is configured (`STELLAR_HORIZON_URL` or `STELLAR_HORIZON_URLS`). If Horizon is not configured, the relay skips this check (local/dev only).
+
+## Implementation
+
+- `fluid-server/src/signer_weight.rs` – pure validation + unit tests
+- `fluid-server/src/horizon.rs` – `fetch_account_auth`
+- `fluid-server/src/main.rs` – invoked in `process_fee_bump_request` before signing

--- a/fluid-server/src/horizon.rs
+++ b/fluid-server/src/horizon.rs
@@ -10,7 +10,11 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::info;
 
-use crate::{config::HorizonSelectionStrategy, error::AppError};
+use crate::{
+    config::HorizonSelectionStrategy,
+    error::AppError,
+    signer_weight::HorizonAccountAuth,
+};
 
 #[derive(Clone, Serialize)]
 pub struct HorizonNodeStatus {
@@ -190,6 +194,75 @@ impl HorizonCluster {
             "SUBMISSION_FAILED",
             format!(
                 "Transaction submission failed: {}",
+                last_error.unwrap_or_else(|| "all Horizon nodes failed".to_string())
+            ),
+        ))
+    }
+
+    pub async fn fetch_account_auth(&self, account_id: &str) -> Result<HorizonAccountAuth, AppError> {
+        let order = self.node_order().await;
+        let mut last_error = None;
+
+        for node_index in order {
+            let node_url = self.node_url(node_index).await;
+            let response = self
+                .client
+                .get(format!("{node_url}/accounts/{account_id}"))
+                .send()
+                .await;
+
+            match response {
+                Ok(response) if response.status().is_success() => {
+                    let body = response.json().await.map_err(|error| {
+                        AppError::new(
+                            StatusCode::BAD_GATEWAY,
+                            "HORIZON_LOOKUP_FAILED",
+                            format!("Failed to decode Horizon account response: {error}"),
+                        )
+                    })?;
+                    self.mark_node_active(node_index).await;
+                    return Ok(body);
+                }
+                Ok(response) if response.status() == StatusCode::NOT_FOUND => {
+                    return Err(AppError::new(
+                        StatusCode::BAD_REQUEST,
+                        "ACCOUNT_NOT_FOUND",
+                        format!("Source account {account_id} was not found on the network"),
+                    ));
+                }
+                Ok(response) => {
+                    let status = response.status();
+                    let body = response.text().await.unwrap_or_default();
+                    match classify_http_error(status, &body) {
+                        HorizonErrorDisposition::Retryable(message) => {
+                            self.mark_node_inactive(node_index, &message).await;
+                            last_error = Some(message);
+                            continue;
+                        }
+                        HorizonErrorDisposition::Final(message) => {
+                            self.mark_node_checked(node_index, Some(message.clone()))
+                                .await;
+                            return Err(AppError::new(
+                                StatusCode::BAD_GATEWAY,
+                                "HORIZON_LOOKUP_FAILED",
+                                format!("Horizon account lookup failed: {message}"),
+                            ));
+                        }
+                    }
+                }
+                Err(error) => {
+                    let message = error.to_string();
+                    self.mark_node_inactive(node_index, &message).await;
+                    last_error = Some(message);
+                }
+            }
+        }
+
+        Err(AppError::new(
+            StatusCode::BAD_GATEWAY,
+            "HORIZON_LOOKUP_FAILED",
+            format!(
+                "Horizon account lookup failed: {}",
                 last_error.unwrap_or_else(|| "all Horizon nodes failed".to_string())
             ),
         ))

--- a/fluid-server/src/main.rs
+++ b/fluid-server/src/main.rs
@@ -10,6 +10,7 @@ mod metrics;
 mod notifications;
 mod profiling;
 mod state;
+mod signer_weight;
 mod stellar;
 mod tracing_ctx;
 pub use fluid_server::xdr;
@@ -650,6 +651,34 @@ async fn process_fee_bump_request(
                          maximum of {limit} per envelope (FLUID_MAX_OPERATIONS_PER_ENVELOPE)."
                     ),
                 ));
+            }
+        }
+    }
+
+    // #686 – Pre-flight validation: inner tx signature weight vs source med_threshold.
+    if !state.config.horizon_urls.is_empty() {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        use stellar_xdr::curr::{Limits, ReadXdr, TransactionEnvelope};
+
+        if let Ok(bytes) = STANDARD.decode(xdr.trim()) {
+            if let Ok(envelope) = TransactionEnvelope::from_xdr(bytes, Limits::none()) {
+                if let TransactionEnvelope::Tx(inner) = &envelope {
+                    match signer_weight::inner_source_account_id(inner) {
+                        Ok(source_account) => {
+                            let account_auth = state
+                                .horizon
+                                .fetch_account_auth(&source_account)
+                                .await?;
+                            if let Err(err) = signer_weight::validate_inner_envelope_signer_weight(
+                                inner,
+                                &account_auth,
+                            ) {
+                                return Err(err.into_app_error());
+                            }
+                        }
+                        Err(err) => return Err(err.into_app_error()),
+                    }
+                }
             }
         }
     }

--- a/fluid-server/src/mock_horizon.rs
+++ b/fluid-server/src/mock_horizon.rs
@@ -91,6 +91,7 @@ struct ServerState {
     config: Arc<Mutex<MockHorizonConfig>>,
     requests: Arc<Mutex<Vec<CapturedRequest>>>,
     request_count: Arc<AtomicUsize>,
+    account_overrides: Arc<Mutex<HashMap<String, serde_json::Value>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,7 @@ impl MockHorizonServer {
                 config: Arc::new(Mutex::new(MockHorizonConfig::default())),
                 requests: Arc::new(Mutex::new(Vec::new())),
                 request_count: Arc::new(AtomicUsize::new(0)),
+                account_overrides: Arc::new(Mutex::new(HashMap::new())),
             },
             shutdown_tx: None,
             addr: None,
@@ -184,6 +186,16 @@ impl MockHorizonServer {
         drop(cfg);
         self.state.request_count.store(0, Ordering::SeqCst);
         self.state.requests.lock().unwrap().clear();
+        self.state.account_overrides.lock().unwrap().clear();
+    }
+
+    /// Override Horizon account auth fields (`thresholds`, `signers`) for a public key.
+    pub fn set_account_auth(&self, account_id: &str, auth: serde_json::Value) {
+        self.state
+            .account_overrides
+            .lock()
+            .unwrap()
+            .insert(account_id.to_string(), auth);
     }
 }
 
@@ -238,12 +250,12 @@ async fn handle_request(State(state): State<ServerState>, req: Request<Body>) ->
         sleep(Duration::from_millis(latency_ms)).await;
     }
 
-    build_response(&path, scenario).await
+    build_response(&state, &path, scenario).await
 }
 
-async fn build_response(path: &str, scenario: HorizonScenario) -> Response {
+async fn build_response(state: &ServerState, path: &str, scenario: HorizonScenario) -> Response {
     match scenario {
-        HorizonScenario::Success => success_response(path),
+        HorizonScenario::Success => success_response(state, path),
 
         HorizonScenario::RateLimit => (
             StatusCode::TOO_MANY_REQUESTS,
@@ -339,7 +351,7 @@ async fn build_response(path: &str, scenario: HorizonScenario) -> Response {
     }
 }
 
-fn success_response(path: &str) -> Response {
+fn success_response(state: &ServerState, path: &str) -> Response {
     let body = match path {
         "/fee_stats" => json!({
             "last_ledger": "123456",
@@ -378,11 +390,33 @@ fn success_response(path: &str) -> Response {
                 "p99": "200"
             }
         }),
-        p if p.starts_with("/accounts/") => json!({
-            "id": "GABC",
-            "sequence": "1234567890",
-            "balances": [{"asset_type": "native", "balance": "100.0000000"}]
-        }),
+        p if p.starts_with("/accounts/") => {
+            let account_id = p.trim_start_matches("/accounts/");
+            let mut account = json!({
+                "id": account_id,
+                "sequence": "1234567890",
+                "balances": [{"asset_type": "native", "balance": "100.0000000"}],
+                "thresholds": {
+                    "low_threshold": 0,
+                    "med_threshold": 0,
+                    "high_threshold": 0
+                },
+                "signers": [{
+                    "weight": 1,
+                    "key": account_id,
+                    "type": "ed25519_public_key"
+                }]
+            });
+            if let Some(override_auth) = state.account_overrides.lock().unwrap().get(account_id) {
+                if let Some(thresholds) = override_auth.get("thresholds") {
+                    account["thresholds"] = thresholds.clone();
+                }
+                if let Some(signers) = override_auth.get("signers") {
+                    account["signers"] = signers.clone();
+                }
+            }
+            account
+        }
         "/transactions" => json!({
             "hash": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
             "successful": true,

--- a/fluid-server/src/signer_weight.rs
+++ b/fluid-server/src/signer_weight.rs
@@ -1,0 +1,405 @@
+//! Pre-flight validation of inner transaction signature weight (#686).
+//!
+//! Before wrapping an inner transaction in a fee-bump envelope, the relay verifies
+//! that the signatures on the inner envelope meet the source account's
+//! `med_threshold` (Stellar's requirement for submitting operations).
+
+use axum::http::StatusCode;
+use serde::Deserialize;
+use stellar_strkey::{ed25519::PublicKey, Strkey};
+use stellar_xdr::curr::{
+    DecoratedSignature, SignatureHint, TransactionEnvelope,
+    TransactionV1Envelope,
+};
+
+use crate::error::AppError;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AccountThresholds {
+    pub low_threshold: u32,
+    pub med_threshold: u32,
+    pub high_threshold: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HorizonSigner {
+    pub key: String,
+    pub weight: u32,
+    #[serde(rename = "type")]
+    pub signer_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HorizonAccountAuth {
+    pub thresholds: AccountThresholds,
+    pub signers: Vec<HorizonSigner>,
+}
+
+#[derive(Debug)]
+pub enum SignerWeightError {
+    InsufficientWeight { actual: u32, required: u32 },
+    UnsupportedSourceAccount,
+    NoMatchingSigners,
+}
+
+impl SignerWeightError {
+    pub fn into_app_error(self) -> AppError {
+        match self {
+            Self::InsufficientWeight { actual, required } => AppError::new(
+                StatusCode::BAD_REQUEST,
+                "INSUFFICIENT_SIGNATURE_WEIGHT",
+                format!(
+                    "Inner transaction signature weight ({actual}) is below the source \
+                     account med_threshold ({required})"
+                ),
+            ),
+            Self::UnsupportedSourceAccount => AppError::new(
+                StatusCode::BAD_REQUEST,
+                "UNSUPPORTED_SOURCE_ACCOUNT",
+                "Only classic ed25519 source accounts are supported for signer-weight validation",
+            ),
+            Self::NoMatchingSigners => AppError::new(
+                StatusCode::BAD_REQUEST,
+                "INSUFFICIENT_SIGNATURE_WEIGHT",
+                "Inner transaction signatures do not match any configured account signers",
+            ),
+        }
+    }
+}
+
+/// Compute the total signature weight contributed by `signatures` against `account`.
+pub fn total_signature_weight(
+    signatures: &[DecoratedSignature],
+    account: &HorizonAccountAuth,
+) -> Result<u32, SignerWeightError> {
+    if signatures.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total = 0u32;
+    let mut matched_any = false;
+
+    for signature in signatures {
+        let Some(weight) = weight_for_hint(&signature.hint, account) else {
+            continue;
+        };
+        matched_any = true;
+        total = total.saturating_add(weight);
+    }
+
+    if !matched_any {
+        return Err(SignerWeightError::NoMatchingSigners);
+    }
+
+    Ok(total)
+}
+
+/// Validate that a classic V1 inner envelope meets the source account `med_threshold`.
+pub fn validate_inner_envelope_signer_weight(
+    inner: &TransactionV1Envelope,
+    account: &HorizonAccountAuth,
+) -> Result<(), SignerWeightError> {
+    let required = account.thresholds.med_threshold;
+    let actual = total_signature_weight(&inner.signatures, account)?;
+
+    if actual < required {
+        return Err(SignerWeightError::InsufficientWeight { actual, required });
+    }
+
+    Ok(())
+}
+
+/// Validate signer weight for a parsed transaction envelope about to be fee-bumped.
+pub fn validate_transaction_envelope_signer_weight(
+    envelope: &TransactionEnvelope,
+    account: &HorizonAccountAuth,
+) -> Result<(), SignerWeightError> {
+    match envelope {
+        TransactionEnvelope::Tx(inner) => validate_inner_envelope_signer_weight(inner, account),
+        TransactionEnvelope::TxV0(_) => Err(SignerWeightError::UnsupportedSourceAccount),
+        TransactionEnvelope::TxFeeBump(_) => Err(SignerWeightError::UnsupportedSourceAccount),
+    }
+}
+
+fn weight_for_hint(hint: &SignatureHint, account: &HorizonAccountAuth) -> Option<u32> {
+    for signer in &account.signers {
+        if signer.signer_type != "ed25519_public_key" {
+            continue;
+        }
+        let Ok(Strkey::PublicKeyEd25519(PublicKey(bytes))) = Strkey::from_string(&signer.key)
+        else {
+            continue;
+        };
+        if signature_hint_matches(&bytes, hint) {
+            return Some(signer.weight);
+        }
+    }
+    None
+}
+
+fn signature_hint_matches(public_key: &[u8; 32], hint: &SignatureHint) -> bool {
+    hint.0 == [
+        public_key[28],
+        public_key[29],
+        public_key[30],
+        public_key[31],
+    ]
+}
+
+/// Extract the classic ed25519 account id (G...) from a fee-bump inner envelope.
+pub fn inner_source_account_id(inner: &TransactionV1Envelope) -> Result<String, SignerWeightError> {
+    match &inner.tx.source_account {
+        stellar_xdr::curr::MuxedAccount::Ed25519(key) => Ok(Strkey::PublicKeyEd25519(PublicKey(key.0))
+            .to_string()
+            .to_string()),
+        _ => Err(SignerWeightError::UnsupportedSourceAccount),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use sha2::{Digest, Sha256};
+    use stellar_xdr::curr::{
+        Asset, Hash, Limits, Memo, MuxedAccount, Operation, OperationBody, PaymentOp,
+        Preconditions, SequenceNumber, Signature, Transaction, TransactionExt,
+        TransactionSignaturePayload, TransactionSignaturePayloadTaggedTransaction, Uint256,
+        WriteXdr,
+    };
+
+    fn test_account(master_weight: u32, med_threshold: u32) -> (String, HorizonAccountAuth) {
+        let secret = [11_u8; 32];
+        let signing_key = SigningKey::from_bytes(&secret);
+        let public_bytes = signing_key.verifying_key().to_bytes();
+        let account_id = Strkey::PublicKeyEd25519(PublicKey(public_bytes))
+            .to_string()
+            .to_string();
+
+        let auth = HorizonAccountAuth {
+            thresholds: AccountThresholds {
+                low_threshold: 0,
+                med_threshold,
+                high_threshold: 255,
+            },
+            signers: vec![HorizonSigner {
+                key: account_id.clone(),
+                weight: master_weight,
+                signer_type: "ed25519_public_key".to_string(),
+            }],
+        };
+
+        (account_id, auth)
+    }
+
+    fn sign_v1_envelope(
+        tx: Transaction,
+        signing_key: &SigningKey,
+        network_passphrase: &str,
+    ) -> TransactionV1Envelope {
+        let source = match &tx.source_account {
+            MuxedAccount::Ed25519(key) => key.0,
+            _ => [0u8; 32],
+        };
+        let network_hash: [u8; 32] = Sha256::digest(network_passphrase.as_bytes()).into();
+        let payload = TransactionSignaturePayload {
+            network_id: Hash(network_hash),
+            tagged_transaction: TransactionSignaturePayloadTaggedTransaction::Tx(tx.clone()),
+        };
+        let payload_xdr = payload.to_xdr(Limits::none()).unwrap();
+        let tx_hash: [u8; 32] = Sha256::digest(payload_xdr).into();
+        let signature = signing_key.sign(&tx_hash).to_bytes();
+
+        TransactionV1Envelope {
+            tx,
+            signatures: vec![DecoratedSignature {
+                hint: SignatureHint([source[28], source[29], source[30], source[31]]),
+                signature: Signature(signature.to_vec().try_into().unwrap()),
+            }]
+            .try_into()
+            .unwrap(),
+        }
+    }
+
+    #[test]
+    fn accepts_when_signature_weight_meets_med_threshold() {
+        let (_account_id, auth) = test_account(2, 2);
+        let secret = [11_u8; 32];
+        let signing_key = SigningKey::from_bytes(&secret);
+        let public_bytes = signing_key.verifying_key().to_bytes();
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256(public_bytes)),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Payment(PaymentOp {
+                    destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
+                    asset: Asset::Native,
+                    amount: 1,
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let inner = sign_v1_envelope(tx, &signing_key, "Test SDF Network ; September 2015");
+        assert!(validate_inner_envelope_signer_weight(&inner, &auth).is_ok());
+    }
+
+    #[test]
+    fn rejects_when_signature_weight_below_med_threshold() {
+        let (_account_id, auth) = test_account(1, 2);
+        let secret = [11_u8; 32];
+        let signing_key = SigningKey::from_bytes(&secret);
+        let public_bytes = signing_key.verifying_key().to_bytes();
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256(public_bytes)),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Payment(PaymentOp {
+                    destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
+                    asset: Asset::Native,
+                    amount: 1,
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let inner = sign_v1_envelope(tx, &signing_key, "Test SDF Network ; September 2015");
+        let err = validate_inner_envelope_signer_weight(&inner, &auth).unwrap_err();
+        assert!(matches!(
+            err,
+            SignerWeightError::InsufficientWeight {
+                actual: 1,
+                required: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_when_no_signature_matches_account_signers() {
+        let (_account_id, auth) = test_account(1, 1);
+        let other_secret = [22_u8; 32];
+        let other_key = SigningKey::from_bytes(&other_secret);
+        let other_public = other_key.verifying_key().to_bytes();
+
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([99u8; 32])),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Payment(PaymentOp {
+                    destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
+                    asset: Asset::Native,
+                    amount: 1,
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let inner = sign_v1_envelope(tx, &other_key, "Test SDF Network ; September 2015");
+        assert_eq!(inner.tx.source_account, MuxedAccount::Ed25519(Uint256([99u8; 32])));
+        let _ = other_public;
+        let err = validate_inner_envelope_signer_weight(&inner, &auth).unwrap_err();
+        assert!(matches!(err, SignerWeightError::NoMatchingSigners));
+    }
+
+    #[test]
+    fn sums_weights_from_multiple_signers() {
+        let secret_a = [31_u8; 32];
+        let secret_b = [32_u8; 32];
+        let key_a = SigningKey::from_bytes(&secret_a);
+        let key_b = SigningKey::from_bytes(&secret_b);
+        let id_a = Strkey::PublicKeyEd25519(PublicKey(key_a.verifying_key().to_bytes()))
+            .to_string()
+            .to_string();
+        let id_b = Strkey::PublicKeyEd25519(PublicKey(key_b.verifying_key().to_bytes()))
+            .to_string()
+            .to_string();
+
+        let auth = HorizonAccountAuth {
+            thresholds: AccountThresholds {
+                low_threshold: 0,
+                med_threshold: 3,
+                high_threshold: 5,
+            },
+            signers: vec![
+                HorizonSigner {
+                    key: id_a.clone(),
+                    weight: 1,
+                    signer_type: "ed25519_public_key".to_string(),
+                },
+                HorizonSigner {
+                    key: id_b.clone(),
+                    weight: 2,
+                    signer_type: "ed25519_public_key".to_string(),
+                },
+            ],
+        };
+
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256(key_a.verifying_key().to_bytes())),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Payment(PaymentOp {
+                    destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
+                    asset: Asset::Native,
+                    amount: 1,
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let network_hash: [u8; 32] =
+            Sha256::digest("Test SDF Network ; September 2015".as_bytes()).into();
+        let payload = TransactionSignaturePayload {
+            network_id: Hash(network_hash),
+            tagged_transaction: TransactionSignaturePayloadTaggedTransaction::Tx(tx.clone()),
+        };
+        let tx_hash: [u8; 32] = Sha256::digest(payload.to_xdr(Limits::none()).unwrap()).into();
+
+        let bytes_a = key_a.verifying_key().to_bytes();
+        let bytes_b = key_b.verifying_key().to_bytes();
+        let sig_a = key_a.sign(&tx_hash).to_bytes();
+        let sig_b = key_b.sign(&tx_hash).to_bytes();
+
+        let inner = TransactionV1Envelope {
+            tx,
+            signatures: vec![
+                DecoratedSignature {
+                    hint: SignatureHint([bytes_a[28], bytes_a[29], bytes_a[30], bytes_a[31]]),
+                    signature: Signature(sig_a.to_vec().try_into().unwrap()),
+                },
+                DecoratedSignature {
+                    hint: SignatureHint([bytes_b[28], bytes_b[29], bytes_b[30], bytes_b[31]]),
+                    signature: Signature(sig_b.to_vec().try_into().unwrap()),
+                },
+            ]
+            .try_into()
+            .unwrap(),
+        };
+
+        assert!(validate_inner_envelope_signer_weight(&inner, &auth).is_ok());
+    }
+}

--- a/fluid-server/tests/signer_weight_integration.rs
+++ b/fluid-server/tests/signer_weight_integration.rs
@@ -1,0 +1,199 @@
+//! Integration coverage for inner-transaction signer-weight preflight (#686).
+
+use base64::Engine;
+use ed25519_dalek::{Signer, SigningKey};
+use reqwest::Client;
+use sha2::{Digest, Sha256};
+use stellar_strkey::{ed25519, Strkey};
+use stellar_xdr::curr::{
+    Asset, DecoratedSignature, Hash, Limits, Memo, MuxedAccount, Operation, OperationBody,
+    PaymentOp, Preconditions, SequenceNumber, Signature, SignatureHint, Transaction,
+    TransactionEnvelope, TransactionExt, TransactionSignaturePayload,
+    TransactionSignaturePayloadTaggedTransaction, TransactionV1Envelope, Uint256, WriteXdr,
+};
+
+fn build_secret(seed_byte: u8) -> String {
+    Strkey::PrivateKeyEd25519(ed25519::PrivateKey([seed_byte; 32]))
+        .to_string()
+        .to_string()
+}
+
+fn build_signed_transaction_xdr(seed_byte: u8, med_threshold: u32) -> (String, String) {
+    let secret = [seed_byte; 32];
+    let signing_key = SigningKey::from_bytes(&secret);
+    let source = signing_key.verifying_key().to_bytes();
+    let account_id = Strkey::PublicKeyEd25519(stellar_strkey::ed25519::PublicKey(source))
+        .to_string()
+        .to_string();
+    let destination = [7_u8; 32];
+
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256(source)),
+        fee: 100,
+        seq_num: SequenceNumber(42),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![Operation {
+            source_account: None,
+            body: OperationBody::Payment(PaymentOp {
+                destination: MuxedAccount::Ed25519(Uint256(destination)),
+                asset: Asset::Native,
+                amount: 10_000_000,
+            }),
+        }]
+        .try_into()
+        .unwrap(),
+        ext: TransactionExt::V0,
+    };
+
+    let network_hash: [u8; 32] =
+        Sha256::digest("Test SDF Network ; September 2015".as_bytes()).into();
+    let payload = TransactionSignaturePayload {
+        network_id: Hash(network_hash),
+        tagged_transaction: TransactionSignaturePayloadTaggedTransaction::Tx(tx.clone()),
+    };
+    let payload_xdr = payload.to_xdr(Limits::none()).unwrap();
+    let tx_hash: [u8; 32] = Sha256::digest(payload_xdr).into();
+    let signature = signing_key.sign(&tx_hash).to_bytes();
+
+    let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx,
+        signatures: vec![DecoratedSignature {
+            hint: SignatureHint([source[28], source[29], source[30], source[31]]),
+            signature: Signature(signature.to_vec().try_into().unwrap()),
+        }]
+        .try_into()
+        .unwrap(),
+    });
+
+    let xdr = base64::engine::general_purpose::STANDARD.encode(envelope.to_xdr(Limits::none()).unwrap());
+    let _ = med_threshold;
+    (xdr, account_id)
+}
+
+#[tokio::test]
+async fn fee_bump_preflight_signer_weight_integration() {
+    let mut mock = fluid_server::mock_horizon::MockHorizonServer::new();
+    let horizon_base = mock.start().await;
+    let server = TestServer::spawn(&horizon_base).await;
+    let client = Client::new();
+
+    // Insufficient weight: med_threshold 2, signer weight 1.
+    let (insufficient_xdr, insufficient_account) = build_signed_transaction_xdr(9, 2);
+    mock.set_account_auth(
+        &insufficient_account,
+        serde_json::json!({
+            "thresholds": {
+                "low_threshold": 0,
+                "med_threshold": 2,
+                "high_threshold": 5
+            },
+            "signers": [{
+                "weight": 1,
+                "key": insufficient_account,
+                "type": "ed25519_public_key"
+            }]
+        }),
+    );
+
+    let rejected = client
+        .post(format!("{}/fee-bump", server.base_url))
+        .header("x-api-key", "fluid-pro-demo-key")
+        .json(&serde_json::json!({ "xdr": insufficient_xdr, "submit": false }))
+        .send()
+        .await
+        .expect("fee-bump request should complete");
+
+    assert_eq!(rejected.status(), 400);
+    let rejected_body: serde_json::Value = rejected.json().await.unwrap();
+    assert_eq!(rejected_body["code"], "INSUFFICIENT_SIGNATURE_WEIGHT");
+
+    // Sufficient weight: med_threshold 1, signer weight 1.
+    let (sufficient_xdr, sufficient_account) = build_signed_transaction_xdr(10, 1);
+    mock.set_account_auth(
+        &sufficient_account,
+        serde_json::json!({
+            "thresholds": {
+                "low_threshold": 0,
+                "med_threshold": 1,
+                "high_threshold": 5
+            },
+            "signers": [{
+                "weight": 1,
+                "key": sufficient_account,
+                "type": "ed25519_public_key"
+            }]
+        }),
+    );
+
+    let accepted = client
+        .post(format!("{}/fee-bump", server.base_url))
+        .header("x-api-key", "fluid-pro-demo-key")
+        .json(&serde_json::json!({ "xdr": sufficient_xdr, "submit": false }))
+        .send()
+        .await
+        .expect("fee-bump request should complete");
+
+    assert_eq!(accepted.status(), 200);
+    let accepted_body: serde_json::Value = accepted.json().await.unwrap();
+    assert_eq!(accepted_body["status"], "ready");
+
+    mock.stop().await;
+}
+
+struct TestServer {
+    base_url: String,
+    child: std::process::Child,
+}
+
+impl TestServer {
+    async fn spawn(horizon_url: &str) -> Self {
+        use std::process::{Command, Stdio};
+
+        let secret = build_secret(1);
+        let http_port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let grpc_port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+
+        let mut child = Command::new(env!("CARGO_BIN_EXE_fluid-server"))
+            .env("PORT", http_port.to_string())
+            .env("GRPC_PORT", grpc_port.to_string())
+            .env("FLUID_FEE_PAYER_SECRET", secret)
+            .env("STELLAR_HORIZON_URL", horizon_url)
+            .env("FLUID_DISABLE_RATE_LIMITS", "true")
+            .env("STELLAR_NETWORK_PASSPHRASE", "Test SDF Network ; September 2015")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("fluid-server should start");
+
+        let base_url = format!("http://127.0.0.1:{http_port}");
+        for _ in 0..60 {
+            if Client::new()
+                .get(format!("{base_url}/health"))
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false)
+            {
+                return Self { base_url, child };
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+
+        let _ = child.kill();
+        panic!("fluid-server did not become healthy");
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}

--- a/fluid-server/verification/dependency-scans-integration.txt
+++ b/fluid-server/verification/dependency-scans-integration.txt
@@ -1,0 +1,25 @@
+Issue #674 – Automated Dependency Vulnerability Scanners in CI
+================================================================
+
+Workflow
+--------
+.github/workflows/dependency-audit.yml
+
+Matrix scanners
+---------------
+- cargo-audit (fluid-server/)
+- npm audit (fluid-server/wasm-demo/)
+
+Local verification (from fluid-server/)
+-----------------------------------------
+cargo install cargo-audit --locked
+cargo audit
+
+cd wasm-demo && npm ci && npm audit --audit-level=high
+
+CI behavior
+-----------
+- Runs on pull requests and pushes touching fluid-server/**
+- Uploads JSON audit reports as workflow artifacts
+- Fails the job on high/critical Rust advisories (`cargo audit --deny warnings`)
+- Fails the job on high+ npm vulnerabilities (`npm audit --audit-level=high`)

--- a/fluid-server/verification/inner-transaction-signer-weight.txt
+++ b/fluid-server/verification/inner-transaction-signer-weight.txt
@@ -1,0 +1,18 @@
+Issue #686 – Pre-flight Validation of Inner Transaction Signer Weight
+=======================================================================
+
+Implementation
+--------------
+- fluid-server/src/signer_weight.rs
+- fluid-server/src/horizon.rs (fetch_account_auth)
+- fluid-server/src/main.rs (process_fee_bump_request hook)
+- fluid-server/docs/inner-transaction-signer-weight-validation.md
+
+Verification (run from fluid-server/)
+-------------------------------------
+cargo test signer_weight -- --nocapture
+cargo test signer_weight_integration -- --nocapture
+
+Expected:
+- Unit tests cover sufficient weight, insufficient weight, multi-signer sums, and no matching signers.
+- Integration tests exercise /fee-bump with mock Horizon account overrides.


### PR DESCRIPTION
## Summary

This PR implements two `fluid-server` hardening items:

- **#674 – Dependency vulnerability scanning in CI**: Adds a matrix workflow that runs `cargo-audit` on the Rust crate and `npm audit` on `fluid-server/wasm-demo`, uploads JSON reports as artifacts, and fails builds on high/critical findings.
- **#686 – Inner transaction signer-weight preflight**: Before fee-bumping, the relay fetches the source account from Horizon and verifies inner envelope signature weight meets `med_threshold`, returning `INSUFFICIENT_SIGNATURE_WEIGHT` when it does not.

## Changes

### CI / supply chain (#674)
- `.github/workflows/dependency-audit.yml` – PR/push matrix (`cargo-audit`, `npm-audit`)
- `fluid-server/audit.toml` – cargo-audit config stub for reviewed advisories
- `fluid-server/verification/dependency-scans-integration.txt` – verification notes

### Resilience (#686)
- `fluid-server/src/signer_weight.rs` – weight calculation + validation
- `fluid-server/src/horizon.rs` – `fetch_account_auth`
- `fluid-server/src/main.rs` – preflight hook in `process_fee_bump_request`
- `fluid-server/src/mock_horizon.rs` – per-account auth overrides for tests
- `fluid-server/tests/signer_weight_integration.rs` – end-to-end `/fee-bump` checks
- `fluid-server/docs/inner-transaction-signer-weight-validation.md`

## Test plan

From `fluid-server/`:

```bash
# Signer-weight unit tests
cargo test signer_weight::tests -- --nocapture

# Signer-weight integration (mock Horizon + live server)
cargo test --test signer_weight_integration -- --nocapture

# Dependency scans (local)
cargo install cargo-audit --locked && cargo audit
cd wasm-demo && npm ci && npm audit --audit-level=high
```

Verified locally:
- `cargo test signer_weight::tests` – 4 passed
- `cargo test --test signer_weight_integration` – 1 passed (reject insufficient weight + accept sufficient weight)

## Screenshots / terminal output

Reviewer verification files:
- `fluid-server/verification/dependency-scans-integration.txt`
- `fluid-server/verification/inner-transaction-signer-weight.txt`

Closes #674
Closes #686

Made with [Cursor](https://cursor.com)