### PR TITLE
feat: resilience & error handling - issues #688, #691, #692, #687

### DIFF
--- a/fluid-server/src/blocklist.rs
+++ b/fluid-server/src/blocklist.rs
@@ -1,5 +1,26 @@
 use std::collections::HashMap;
 
+/// Normalise an address for blocklist lookups.
+///
+/// Muxed accounts (M...) share the same underlying ed25519 key as their base
+/// G... account.  To avoid bypassing a block by using a muxed variant, we
+/// resolve M... addresses to their base G... key before storing or checking.
+///
+/// If the address cannot be parsed as a muxed account it is returned as-is,
+/// so plain G... addresses and any other strings pass through unchanged.
+fn normalize_address(address: &str) -> String {
+    use stellar_strkey::Strkey;
+    use stellar_strkey::ed25519::PublicKey;
+
+    // Attempt to parse as a muxed account (M...).
+    if let Ok(Strkey::MuxedAccountEd25519(muxed)) = Strkey::from_string(address) {
+        // Return the underlying G... account id.
+        return Strkey::PublicKeyEd25519(PublicKey(muxed.ed25519)).to_string();
+    }
+
+    address.to_string()
+}
+
 #[derive(Clone)]
 pub struct BlockEntry {
     pub reason: String,
@@ -19,10 +40,11 @@ impl Blocklist {
     }
 
     pub fn add(&mut self, key: String, reason: String, now: u64) {
-        println!("[BLOCKLIST] {} → {}", key, reason);
+        let normalized = normalize_address(&key);
+        println!("[BLOCKLIST] {} → {}", normalized, reason);
 
         self.entries.insert(
-            key,
+            normalized,
             BlockEntry {
                 reason,
                 expiry: Some(now + 3600), // 1 hour expiry
@@ -32,20 +54,21 @@ impl Blocklist {
     }
 
     pub fn is_blocked(&self, key: &str, now: u64) -> bool {
-        if let Some(entry) = self.entries.get(key) {
+        let normalized = normalize_address(key);
+        if let Some(entry) = self.entries.get(&normalized) {
             let age_seconds = now.saturating_sub(entry.created_at);
             if let Some(expiry) = entry.expiry {
                 if now >= expiry {
                     println!(
                         "[BLOCKLIST] Expired block for {} (reason: {}, age={}s)",
-                        key, entry.reason, age_seconds
+                        normalized, entry.reason, age_seconds
                     );
                 }
                 return now < expiry;
             }
             println!(
                 "[BLOCKLIST] Active permanent block for {} (reason: {}, age={}s)",
-                key, entry.reason, age_seconds
+                normalized, entry.reason, age_seconds
             );
             return true;
         }

--- a/fluid-server/src/logging.rs
+++ b/fluid-server/src/logging.rs
@@ -1,5 +1,8 @@
 use std::{
     fmt,
+    fs::{File, OpenOptions},
+    io::Write,
+    path::PathBuf,
     str::FromStr,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -351,23 +354,46 @@ async fn export_worker(config: LogAggregationConfig, mut receiver: mpsc::Receive
         return;
     };
 
+    // Consecutive remote-export failures before falling back to disk.
+    let mut consecutive_failures: u32 = 0;
+    const FALLBACK_THRESHOLD: u32 = 3;
+
     let mut batch = Vec::with_capacity(config.batch_size);
     loop {
         tokio::select! {
             Some(record) = receiver.recv() => {
                 batch.push(record);
                 if batch.len() >= config.batch_size {
-                    flush_batch(&client, &config, &mut batch).await;
+                    let failed = flush_batch(&client, &config, &mut batch).await;
+                    if failed {
+                        consecutive_failures += 1;
+                        if consecutive_failures >= FALLBACK_THRESHOLD {
+                            flush_batch_to_disk(&config, &mut batch);
+                        }
+                    } else {
+                        consecutive_failures = 0;
+                    }
                 }
             }
             _ = interval.tick() => {
                 if !batch.is_empty() {
-                    flush_batch(&client, &config, &mut batch).await;
+                    let failed = flush_batch(&client, &config, &mut batch).await;
+                    if failed {
+                        consecutive_failures += 1;
+                        if consecutive_failures >= FALLBACK_THRESHOLD {
+                            flush_batch_to_disk(&config, &mut batch);
+                        }
+                    } else {
+                        consecutive_failures = 0;
+                    }
                 }
             }
             else => {
                 if !batch.is_empty() {
-                    flush_batch(&client, &config, &mut batch).await;
+                    let failed = flush_batch(&client, &config, &mut batch).await;
+                    if failed {
+                        flush_batch_to_disk(&config, &mut batch);
+                    }
                 }
                 break;
             }
@@ -375,19 +401,19 @@ async fn export_worker(config: LogAggregationConfig, mut receiver: mpsc::Receive
     }
 }
 
-async fn flush_batch(client: &reqwest::Client, config: &LogAggregationConfig, batch: &mut Vec<AggregatedLog>) {
+async fn flush_batch(client: &reqwest::Client, config: &LogAggregationConfig, batch: &mut Vec<AggregatedLog>) -> bool {
     let payload = match build_payload(config, batch) {
         Ok(payload) => payload,
         Err(error) => {
             eprintln!("[log-aggregation] failed to build payload: {error}");
             batch.clear();
-            return;
+            return true; // treat serialisation failure as a remote failure
         }
     };
 
     let Some(endpoint) = config.endpoint.as_deref() else {
         batch.clear();
-        return;
+        return false;
     };
 
     let mut request = client.post(endpoint);
@@ -411,19 +437,72 @@ async fn flush_batch(client: &reqwest::Client, config: &LogAggregationConfig, ba
     }
 
     let started = Instant::now();
-    match request.body(payload).send().await {
+    let failed = match request.body(payload).send().await {
         Ok(response) if response.status().is_success() => {
             let elapsed = started.elapsed().as_millis();
             tracing::debug!("log batch exported in {elapsed}ms");
+            false
         }
         Ok(response) => {
             eprintln!(
                 "[log-aggregation] export failed with status {}",
                 response.status()
             );
+            true
         }
         Err(error) => {
             eprintln!("[log-aggregation] export request failed: {error}");
+            true
+        }
+    };
+
+    batch.clear();
+    failed
+}
+
+/// Write a batch of log records to a local fallback file when the remote
+/// aggregation service is unavailable.
+///
+/// The file path is controlled by `FLUID_LOG_FALLBACK_PATH` (default:
+/// `fluid-server-fallback.log` in the current working directory).  Each
+/// record is written as a single JSON line (NDJSON) so the file can be
+/// ingested by any log shipper once the remote service recovers.
+fn flush_batch_to_disk(config: &LogAggregationConfig, batch: &mut Vec<AggregatedLog>) {
+    if batch.is_empty() {
+        return;
+    }
+
+    let path: PathBuf = std::env::var("FLUID_LOG_FALLBACK_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("fluid-server-fallback.log"));
+
+    let file_result = OpenOptions::new().create(true).append(true).open(&path);
+
+    match file_result {
+        Ok(mut file) => {
+            for record in batch.iter() {
+                match serde_json::to_string(record) {
+                    Ok(line) => {
+                        if let Err(e) = writeln!(file, "{line}") {
+                            eprintln!("[log-aggregation] disk write error: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[log-aggregation] failed to serialise record for disk: {e}");
+                    }
+                }
+            }
+            eprintln!(
+                "[log-aggregation] remote unavailable — {} record(s) written to {}",
+                batch.len(),
+                path.display()
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "[log-aggregation] could not open fallback log file {}: {e}",
+                path.display()
+            );
         }
     }
 

--- a/fluid-server/src/main.rs
+++ b/fluid-server/src/main.rs
@@ -360,6 +360,7 @@ async fn run() -> Result<(), AppError> {
                 listener,
                 app.into_make_service_with_connect_info::<SocketAddr>(),
             )
+            .with_graceful_shutdown(shutdown_signal())
             .await
             .map_err(|error| {
                 AppError::new(
@@ -380,6 +381,40 @@ async fn run() -> Result<(), AppError> {
         }
     )
     .map(|_| ())
+}
+
+/// Resolves when SIGTERM or SIGINT is received, enabling graceful shutdown.
+///
+/// On receipt of a signal the server stops accepting new connections and waits
+/// for in-flight fee-bump requests to complete before the process exits.
+async fn shutdown_signal() {
+    use tokio::signal;
+
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .expect("failed to install CTRL+C handler")
+            .await;
+    };
+
+    #[cfg(unix)]
+    let sigterm = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let sigterm = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {
+            info!("Received SIGINT (Ctrl-C) — initiating graceful shutdown");
+        }
+        _ = sigterm => {
+            info!("Received SIGTERM — initiating graceful shutdown");
+        }
+    }
 }
 
 fn build_cors_layer(allowed_origins: &[String]) -> CorsLayer {

--- a/fluid-server/src/signer_weight.rs
+++ b/fluid-server/src/signer_weight.rs
@@ -56,7 +56,7 @@ impl SignerWeightError {
             Self::UnsupportedSourceAccount => AppError::new(
                 StatusCode::BAD_REQUEST,
                 "UNSUPPORTED_SOURCE_ACCOUNT",
-                "Only classic ed25519 source accounts are supported for signer-weight validation",
+                "Source account type is not supported for signer-weight validation",
             ),
             Self::NoMatchingSigners => AppError::new(
                 StatusCode::BAD_REQUEST,
@@ -147,12 +147,29 @@ fn signature_hint_matches(public_key: &[u8; 32], hint: &SignatureHint) -> bool {
 }
 
 /// Extract the classic ed25519 account id (G...) from a fee-bump inner envelope.
+///
+/// Supports both plain `Ed25519` source accounts and `MuxedEd25519` (M...)
+/// accounts — for the latter the underlying ed25519 key is extracted so that
+/// Horizon can be queried for the base account's thresholds and signers.
 pub fn inner_source_account_id(inner: &TransactionV1Envelope) -> Result<String, SignerWeightError> {
-    match &inner.tx.source_account {
-        stellar_xdr::curr::MuxedAccount::Ed25519(key) => Ok(Strkey::PublicKeyEd25519(PublicKey(key.0))
-            .to_string()
-            .to_string()),
-        _ => Err(SignerWeightError::UnsupportedSourceAccount),
+    muxed_account_to_account_id(&inner.tx.source_account)
+}
+
+/// Resolve a [`MuxedAccount`] to its underlying classic G... account id.
+///
+/// * `Ed25519` — returned directly.
+/// * `MuxedEd25519` — the embedded ed25519 key is extracted; the mux id is
+///   discarded because Horizon account lookups always use the base account.
+pub fn muxed_account_to_account_id(
+    account: &stellar_xdr::curr::MuxedAccount,
+) -> Result<String, SignerWeightError> {
+    use stellar_xdr::curr::MuxedAccount;
+    match account {
+        MuxedAccount::Ed25519(key) => Ok(Strkey::PublicKeyEd25519(PublicKey(key.0)).to_string()),
+        MuxedAccount::MuxedEd25519(muxed) => {
+            // Extract the underlying 32-byte ed25519 key from the muxed account.
+            Ok(Strkey::PublicKeyEd25519(PublicKey(muxed.ed25519.0)).to_string())
+        }
     }
 }
 
@@ -317,6 +334,52 @@ mod tests {
         let _ = other_public;
         let err = validate_inner_envelope_signer_weight(&inner, &auth).unwrap_err();
         assert!(matches!(err, SignerWeightError::NoMatchingSigners));
+    }
+
+    #[test]
+    fn muxed_account_resolves_to_base_account_id() {
+        use stellar_xdr::curr::{MuxedAccountMed25519, VecM};
+        let secret = [11_u8; 32];
+        let signing_key = SigningKey::from_bytes(&secret);
+        let public_bytes = signing_key.verifying_key().to_bytes();
+
+        // Build a transaction whose source is a MuxedEd25519 account.
+        let tx = Transaction {
+            source_account: stellar_xdr::curr::MuxedAccount::MuxedEd25519(
+                MuxedAccountMed25519 {
+                    id: 42,
+                    ed25519: Uint256(public_bytes),
+                },
+            ),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Payment(PaymentOp {
+                    destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
+                    asset: Asset::Native,
+                    amount: 1,
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let inner = TransactionV1Envelope {
+            tx,
+            signatures: VecM::default(),
+        };
+
+        // inner_source_account_id must return the base G... key, not an error.
+        let account_id = inner_source_account_id(&inner).expect("muxed account should resolve");
+        // The resolved id must be a valid G... address.
+        assert!(account_id.starts_with('G'), "expected G... address, got {account_id}");
+        // And it must match the underlying ed25519 key.
+        let expected = Strkey::PublicKeyEd25519(PublicKey(public_bytes)).to_string();
+        assert_eq!(account_id, expected);
     }
 
     #[test]

--- a/server/src/handlers/feeBump.ts
+++ b/server/src/handlers/feeBump.ts
@@ -38,6 +38,9 @@ import {
 } from "../queues/feeBumpQueue";
 import { getFcmNotifier } from "../services/fcmNotifier";
 import { persistTransactionAsync } from "../utils/asyncDbPersist";
+import {
+  markTransactionHashProcessed,
+} from "../utils/redis";
 
 const FEEBUMP_JOB_TIMEOUT_MS = parseInt(
   process.env.FEEBUMP_JOB_TIMEOUT_MS ?? "30000",
@@ -306,6 +309,17 @@ export async function processFeeBump(
   shadowMode?: boolean,
 ): Promise<FeeBumpResponse> {
   const prepared = prepareFeeBump(xdr, config);
+
+  // #688 – Replay-attack prevention: reject duplicate transaction hashes.
+  const isNew = await markTransactionHashProcessed(prepared.innerTxHash);
+  if (!isNew) {
+    throw new AppError(
+      `Duplicate request: transaction ${prepared.innerTxHash} has already been processed.`,
+      409,
+      "DUPLICATE_TRANSACTION",
+    );
+  }
+
   const quotaCheck = await checkTenantDailyQuota(tenant, prepared.feeAmount);
   if (!quotaCheck.allowed) {
     throw new AppError(

--- a/server/src/utils/redis.ts
+++ b/server/src/utils/redis.ts
@@ -255,4 +255,62 @@ export function ensureHashTag(key: string): string {
   return `{${key}}`;
 }
 
+// ─── Replay-attack prevention: short-lived transaction hash cache ─────────────
+
+export const TX_HASH_PREFIX = "txhash:";
+
+/**
+ * Default TTL for processed transaction hashes (5 minutes).
+ * Stellar transactions expire after their time bounds, but 5 minutes is a
+ * reasonable window to catch replay attempts for fee-bump requests.
+ */
+const TX_HASH_TTL_SECONDS = 300;
+
+/**
+ * Mark a transaction hash as processed. Returns true if the hash was newly
+ * recorded, false if it was already present (i.e. a duplicate / replay).
+ *
+ * Uses SET NX (set-if-not-exists) so the check and write are atomic.
+ */
+export async function markTransactionHashProcessed(
+  txHash: string,
+  ttlSeconds = TX_HASH_TTL_SECONDS,
+): Promise<boolean> {
+  try {
+    const key = ensureHashTag(TX_HASH_PREFIX + txHash);
+    // SET key 1 EX ttl NX — returns "OK" on success, null if key already exists
+    const result = await redis.set(key, "1", "EX", ttlSeconds, "NX");
+    return result === "OK";
+  } catch (err) {
+    console.error(
+      "[Redis] markTransactionHashProcessed error:",
+      err instanceof Error ? err.message : err,
+    );
+    // Fail open: if Redis is unavailable, allow the request through rather
+    // than blocking all traffic. The duplicate will be caught by downstream
+    // idempotency checks (e.g. Horizon rejecting a duplicate sequence number).
+    return true;
+  }
+}
+
+/**
+ * Check whether a transaction hash has already been processed without
+ * recording it. Useful for read-only inspection.
+ */
+export async function isTransactionHashProcessed(
+  txHash: string,
+): Promise<boolean> {
+  try {
+    const key = ensureHashTag(TX_HASH_PREFIX + txHash);
+    const val = await redis.get(key);
+    return val !== null;
+  } catch (err) {
+    console.error(
+      "[Redis] isTransactionHashProcessed error:",
+      err instanceof Error ? err.message : err,
+    );
+    return false;
+  }
+}
+
 export default redis;


### PR DESCRIPTION
#688 - Short-lived hash cache to prevent replay attacks (server/)
- Add markTransactionHashProcessed() and isTransactionHashProcessed() to server/src/utils/redis.ts using atomic SET NX with 5-minute TTL
- Integrate replay check in processFeeBump() in feeBump.ts; returns 409 DUPLICATE_TRANSACTION on repeated inner tx hash

#692 - Graceful shutdown in Rust server (fluid-server/)
- Add shutdown_signal() async fn that listens for SIGTERM and SIGINT
- Wire axum::serve().with_graceful_shutdown(shutdown_signal()) so in-flight fee-bump requests complete before the process exits

#691 - Log aggregator failure fallback (fluid-server/)
- flush_batch() now returns bool indicating remote export failure
- After 3 consecutive failures, export_worker() calls flush_batch_to_disk()
- flush_batch_to_disk() writes NDJSON lines to FLUID_LOG_FALLBACK_PATH (default: fluid-server-fallback.log) for later re-ingestion

#687 - Muxed account (M...) support in address validation (fluid-server/)
- inner_source_account_id() now delegates to muxed_account_to_account_id() which handles both Ed25519 and MuxedEd25519 variants
- blocklist.rs normalize_address() strips mux id so M... and G... addresses for the same key share a single blocklist entry
- Add muxed_account_resolves_to_base_account_id test

closes #687 closes #691 closes #692
closes #688 